### PR TITLE
test: add pytest suite covering auth provider and tool handlers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,13 @@ tmux-mcp = "tmux_mcp:main"
 [dependency-groups]
 dev = [
     "ruff>=0.8",
+    "pytest>=8",
+    "pytest-asyncio>=0.24",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["uv_build>=0.11.7,<0.12.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Shared test fixtures.
+
+Every test runs against a temp TMUX_MCP_STATE_DIR so nothing writes to
+~/.config/tmux-mcp. Required env vars are populated with dummy values so
+importing tmux_mcp.server doesn't raise SystemExit at import time.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    state_dir = tmp_path / "tmux-mcp-state"
+    state_dir.mkdir()
+    monkeypatch.setenv("TMUX_MCP_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("TMUX_MCP_PUBLIC_URL", "https://test.example")
+    monkeypatch.setenv("TMUX_MCP_GITHUB_CLIENT_ID", "gh-client-id")
+    monkeypatch.setenv("TMUX_MCP_GITHUB_CLIENT_SECRET", "gh-client-secret")
+    monkeypatch.setenv("TMUX_MCP_ALLOWED_GITHUB_USERS", "alice,bob")
+    # Ensure auth module picks up the temp state dir even if previously imported.
+    for mod in ("tmux_mcp.auth", "tmux_mcp.server"):
+        if mod in os.sys.modules:
+            del os.sys.modules[mod]
+    return state_dir

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,434 @@
+"""Unit tests for tmux_mcp.auth.GithubOAuthProvider.
+
+No real network: httpx.AsyncClient is monkeypatched. No real ~/.config:
+conftest redirects TMUX_MCP_STATE_DIR to a tmp_path per test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt
+import pytest
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _make_provider() -> Any:
+    """Fresh provider instance per test. Imported lazily so conftest's env
+    vars and sys.modules purging apply."""
+    from tmux_mcp.auth import GithubOAuthProvider
+
+    return GithubOAuthProvider(
+        public_url="https://test.example",
+        github_client_id="gh-id",
+        github_client_secret="gh-secret",
+        allowed_github_users={"alice", "BOB"},  # mixed case → lowered internally
+    )
+
+
+def _make_client(client_id: str = "mcp-client-1") -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        redirect_uris=["https://client.example/cb"],
+        token_endpoint_auth_method="none",
+    )
+
+
+def _make_params(state: str = "mcp-state-xyz") -> AuthorizationParams:
+    return AuthorizationParams(
+        state=state,
+        scopes=["mcp:read"],
+        code_challenge="test-pkce-challenge",
+        redirect_uri="https://client.example/cb",
+        redirect_uri_provided_explicitly=True,
+        resource="https://test.example",
+    )
+
+
+def _mock_httpx(monkeypatch: pytest.MonkeyPatch, *, login: str, include_token: bool = True) -> None:
+    """Wire httpx.AsyncClient to return a scripted GitHub token+user response."""
+    import httpx
+
+    tok_resp = MagicMock()
+    tok_resp.raise_for_status = MagicMock()
+    tok_resp.json = MagicMock(
+        return_value={"access_token": "gh-access"} if include_token else {}
+    )
+    user_resp = MagicMock()
+    user_resp.raise_for_status = MagicMock()
+    user_resp.json = MagicMock(return_value={"login": login})
+
+    client = MagicMock()
+    client.post = AsyncMock(return_value=tok_resp)
+    client.get = AsyncMock(return_value=user_resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: client)
+
+
+# ── Allowlist ────────────────────────────────────────────────────────────────
+
+
+class TestAllowlist:
+    def test_empty_allowlist_rejected(self) -> None:
+        from tmux_mcp.auth import GithubOAuthProvider
+
+        with pytest.raises(ValueError, match="ALLOWED_GITHUB_USERS"):
+            GithubOAuthProvider(
+                public_url="https://test.example",
+                github_client_id="x",
+                github_client_secret="x",
+                allowed_github_users=set(),
+            )
+
+    def test_http_public_url_rejected(self) -> None:
+        from tmux_mcp.auth import GithubOAuthProvider
+
+        with pytest.raises(ValueError, match="https"):
+            GithubOAuthProvider(
+                public_url="http://test.example",
+                github_client_id="x",
+                github_client_secret="x",
+                allowed_github_users={"alice"},
+            )
+
+    def test_allowlist_is_lowered(self) -> None:
+        provider = _make_provider()
+        assert provider.allowed_users == {"alice", "bob"}
+
+    async def test_allowed_user_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        params = _make_params()
+        await provider.register_client(_make_client())
+        await provider.authorize(_make_client(), params)
+        state = next(iter(provider._pending))
+
+        _mock_httpx(monkeypatch, login="Alice")  # mixed case — GitHub often returns display-case
+        redirect = await provider.handle_github_callback("gh-code", state)
+
+        assert "code=" in redirect
+        assert state not in provider._pending  # consumed
+
+    async def test_disallowed_user_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        await provider.register_client(_make_client())
+        await provider.authorize(_make_client(), _make_params())
+        state = next(iter(provider._pending))
+
+        _mock_httpx(monkeypatch, login="eve")
+        with pytest.raises(PermissionError, match="not in allowlist"):
+            await provider.handle_github_callback("gh-code", state)
+
+    async def test_github_refusing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        await provider.register_client(_make_client())
+        await provider.authorize(_make_client(), _make_params())
+        state = next(iter(provider._pending))
+
+        _mock_httpx(monkeypatch, login="alice", include_token=False)
+        with pytest.raises(PermissionError, match="declined"):
+            await provider.handle_github_callback("gh-code", state)
+
+
+# ── authorize → callback round-trip ──────────────────────────────────────────
+
+
+class TestAuthorizeRoundtrip:
+    async def test_authorize_stores_pending(self) -> None:
+        provider = _make_provider()
+        params = _make_params()
+        await provider.register_client(_make_client())
+
+        url = await provider.authorize(_make_client(), params)
+
+        assert url.startswith("https://github.com/login/oauth/authorize?")
+        assert len(provider._pending) == 1
+        pending = next(iter(provider._pending.values()))
+        assert pending.code_challenge == "test-pkce-challenge"
+        assert pending.mcp_state == "mcp-state-xyz"
+        assert pending.redirect_uri == "https://client.example/cb"
+
+    async def test_callback_consumes_pending_and_issues_code(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _make_provider()
+        await provider.register_client(_make_client())
+        await provider.authorize(_make_client(), _make_params())
+        state = next(iter(provider._pending))
+
+        _mock_httpx(monkeypatch, login="alice")
+        redirect = await provider.handle_github_callback("gh-code", state)
+
+        assert state not in provider._pending
+        assert len(provider._codes) == 1
+        assert "state=mcp-state-xyz" in redirect
+        assert "code=" in redirect
+
+    async def test_callback_with_unknown_state_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _make_provider()
+        _mock_httpx(monkeypatch, login="alice")
+        with pytest.raises(PermissionError, match="unknown or expired"):
+            await provider.handle_github_callback("gh-code", "no-such-state")
+
+
+# ── Auth codes ───────────────────────────────────────────────────────────────
+
+
+class TestAuthorizationCodes:
+    async def test_code_expiry_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tmux_mcp.auth import AUTH_CODE_TTL
+
+        provider = _make_provider()
+        client = _make_client()
+        await provider.register_client(client)
+        await provider.authorize(client, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+
+        code_str, code = next(iter(provider._codes.items()))
+        code.expires_at = time.time() - 1  # force expiry
+        assert code.expires_at < time.time()
+
+        loaded = await provider.load_authorization_code(client, code_str)
+        assert loaded is None
+        # Expired codes are evicted on load
+        assert code_str not in provider._codes
+        # And the TTL constant is the one we think it is
+        assert AUTH_CODE_TTL == 600
+
+    async def test_code_is_single_use(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        client = _make_client()
+        await provider.register_client(client)
+        await provider.authorize(client, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+
+        code_str = next(iter(provider._codes))
+        loaded = await provider.load_authorization_code(client, code_str)
+        assert loaded is not None
+        await provider.exchange_authorization_code(client, loaded)
+        # Second exchange fails because code is gone
+        assert await provider.load_authorization_code(client, code_str) is None
+
+    async def test_code_wrong_client_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        client_a = _make_client("client-A")
+        client_b = _make_client("client-B")
+        await provider.register_client(client_a)
+        await provider.register_client(client_b)
+        await provider.authorize(client_a, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+
+        code_str = next(iter(provider._codes))
+        # Same code, wrong client → None
+        assert await provider.load_authorization_code(client_b, code_str) is None
+
+
+# ── JWT issuance ─────────────────────────────────────────────────────────────
+
+
+class TestJwtIssuance:
+    async def test_access_and_refresh_tokens_differ(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        client = _make_client()
+        await provider.register_client(client)
+        await provider.authorize(client, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+        code_str = next(iter(provider._codes))
+        code = await provider.load_authorization_code(client, code_str)
+        assert code is not None
+        tokens = await provider.exchange_authorization_code(client, code)
+
+        assert tokens.access_token != tokens.refresh_token
+
+        access_claims = jwt.decode(
+            tokens.access_token,
+            provider._public_pem,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+            issuer="tmux-mcp",
+        )
+        refresh_claims = jwt.decode(
+            tokens.refresh_token,
+            provider._public_pem,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+            issuer="tmux-mcp",
+        )
+        assert access_claims["typ"] == "access"
+        assert refresh_claims["typ"] == "refresh"
+        # refresh lives strictly longer than access
+        assert refresh_claims["exp"] > access_claims["exp"]
+        # same subject + audience
+        assert access_claims["sub"] == refresh_claims["sub"] == "alice"
+        assert access_claims["aud"] == refresh_claims["aud"] == client.client_id
+
+    async def test_load_access_token_rejects_refresh(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        client = _make_client()
+        await provider.register_client(client)
+        await provider.authorize(client, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+        code_str = next(iter(provider._codes))
+        code = await provider.load_authorization_code(client, code_str)
+        tokens = await provider.exchange_authorization_code(client, code)
+
+        # access token loads as access
+        loaded = await provider.load_access_token(tokens.access_token)
+        assert loaded is not None
+        assert loaded.client_id == client.client_id
+
+        # refresh token MUST NOT load as access
+        assert await provider.load_access_token(tokens.refresh_token) is None
+
+    async def test_load_refresh_token_rejects_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = _make_provider()
+        client = _make_client()
+        await provider.register_client(client)
+        await provider.authorize(client, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+        code_str = next(iter(provider._codes))
+        code = await provider.load_authorization_code(client, code_str)
+        tokens = await provider.exchange_authorization_code(client, code)
+
+        assert await provider.load_refresh_token(client, tokens.access_token) is None
+        rt = await provider.load_refresh_token(client, tokens.refresh_token)
+        assert rt is not None
+
+    async def test_refresh_exchange_preserves_sub_and_resource(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _make_provider()
+        client = _make_client()
+        await provider.register_client(client)
+        await provider.authorize(client, _make_params())
+        state = next(iter(provider._pending))
+        _mock_httpx(monkeypatch, login="alice")
+        await provider.handle_github_callback("gh-code", state)
+        code_str = next(iter(provider._codes))
+        code = await provider.load_authorization_code(client, code_str)
+        tokens = await provider.exchange_authorization_code(client, code)
+
+        rt = await provider.load_refresh_token(client, tokens.refresh_token)
+        new_tokens = await provider.exchange_refresh_token(client, rt, scopes=[])
+
+        new_claims = jwt.decode(
+            new_tokens.access_token,
+            provider._public_pem,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+            issuer="tmux-mcp",
+        )
+        assert new_claims["sub"] == "alice"
+        assert new_claims["resource"] == "https://test.example"
+        assert new_claims["aud"] == client.client_id
+
+
+# ── Housekeeping ─────────────────────────────────────────────────────────────
+
+
+class TestHousekeeping:
+    async def test_pending_gc_drops_expired(self) -> None:
+        from tmux_mcp.auth import PENDING_AUTH_TTL, _PendingAuth
+
+        provider = _make_provider()
+        fresh = _PendingAuth(
+            client_id="c",
+            scopes=[],
+            code_challenge="x",
+            redirect_uri="https://client.example/cb",
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+            mcp_state=None,
+        )
+        stale = _PendingAuth(
+            client_id="c",
+            scopes=[],
+            code_challenge="x",
+            redirect_uri="https://client.example/cb",
+            redirect_uri_provided_explicitly=True,
+            resource=None,
+            mcp_state=None,
+        )
+        stale.created_at = time.time() - PENDING_AUTH_TTL - 1
+
+        provider._pending["fresh"] = fresh
+        provider._pending["stale"] = stale
+        provider._gc_pending()
+
+        assert "fresh" in provider._pending
+        assert "stale" not in provider._pending
+
+
+# ── DCR ─────────────────────────────────────────────────────────────────────
+
+
+class TestDynamicClientRegistration:
+    async def test_register_mints_client_id_and_persists(self) -> None:
+        from tmux_mcp.auth import CLIENTS_PATH
+
+        provider = _make_provider()
+        client = OAuthClientInformationFull(
+            client_id="",
+            redirect_uris=["https://client.example/cb"],
+            token_endpoint_auth_method="none",
+        )
+        await provider.register_client(client)
+
+        assert client.client_id.startswith("mcp-")
+        assert CLIENTS_PATH.exists()
+        persisted = json.loads(CLIENTS_PATH.read_text())
+        assert client.client_id in persisted
+
+    async def test_register_mints_client_secret_when_basic_auth(self) -> None:
+        provider = _make_provider()
+        client = OAuthClientInformationFull(
+            client_id="",
+            redirect_uris=["https://client.example/cb"],
+            token_endpoint_auth_method="client_secret_basic",
+        )
+        await provider.register_client(client)
+
+        assert client.client_secret  # minted
+        assert len(client.client_secret) >= 20
+
+    async def test_register_preserves_existing_client_id(self) -> None:
+        provider = _make_provider()
+        client = OAuthClientInformationFull(
+            client_id="preset-id",
+            redirect_uris=["https://client.example/cb"],
+            token_endpoint_auth_method="none",
+        )
+        await provider.register_client(client)
+        assert client.client_id == "preset-id"
+
+    async def test_get_client_roundtrip(self) -> None:
+        provider = _make_provider()
+        original = _make_client("rt-client")
+        await provider.register_client(original)
+
+        loaded = await provider.get_client("rt-client")
+        assert loaded is not None
+        assert loaded.client_id == "rt-client"
+        assert await provider.get_client("does-not-exist") is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,268 @@
+"""Smoke tests for the three tmux tool handlers and the session resolver.
+
+No real tmux — subprocess.run is monkeypatched to return scripted
+(stdout, stderr, returncode) for each invocation. Each test asserts on
+the exact argv the tool would have handed to tmux.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+
+class FakeRun:
+    """Records argv for each subprocess.run call and replays scripted responses."""
+
+    def __init__(self, scripts: list[tuple[str, str, int]] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self._scripts = list(scripts or [])
+        self.default = ("", "", 0)
+
+    def __call__(self, cmd: list[str], **_kwargs: Any) -> subprocess.CompletedProcess:
+        self.calls.append(list(cmd))
+        stdout, stderr, rc = self._scripts.pop(0) if self._scripts else self.default
+        return subprocess.CompletedProcess(args=cmd, returncode=rc, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def fake_run(monkeypatch: pytest.MonkeyPatch) -> FakeRun:
+    """Replace subprocess.run inside the server module with a scripted fake."""
+    from tmux_mcp import server
+
+    fake = FakeRun()
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    return fake
+
+
+# ── tmux_get_summary ─────────────────────────────────────────────────────────
+
+
+class TestGetSummary:
+    async def test_builds_capture_pane_with_target_and_lines(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("hello\nworld\n", "", 0)]
+        result = await server.tmux_get_summary(session="milorg", pane=0, lines=42)
+
+        assert len(fake_run.calls) == 1
+        assert fake_run.calls[0] == [
+            "tmux", "capture-pane", "-p", "-t", "=milorg:.0", "-S", "-42",
+        ]
+        payload = json.loads(result)
+        assert payload["target"] == "=milorg:.0"
+        assert payload["lines_captured"] == 2
+
+    async def test_nonzero_exit_returns_json_error_with_hint(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "can't find session milorg", 1)]
+        result = await server.tmux_get_summary(session="milorg", pane=0, lines=5)
+
+        payload = json.loads(result)
+        assert "error" in payload
+        assert "tmux capture-pane failed" in payload["error"]
+        assert "can't find session" in payload["error"]
+        assert "milorg" in payload["hint"]
+        assert "tmux_list_sessions" in payload["hint"]
+
+
+# ── tmux_send_prompt ─────────────────────────────────────────────────────────
+
+
+class TestSendPrompt:
+    async def test_sends_literal_and_presses_enter_by_default(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "", 0), ("", "", 0)]
+        result = await server.tmux_send_prompt(
+            prompt="echo hi", session="milorg", pane=0
+        )
+
+        assert len(fake_run.calls) == 2
+        # Literal prompt first — note the -l flag to avoid interpreting "Enter" etc. as keys.
+        assert fake_run.calls[0] == [
+            "tmux", "send-keys", "-t", "=milorg:.0", "-l", "echo hi",
+        ]
+        # Then a separate Enter keystroke (without -l so tmux treats it as a key).
+        assert fake_run.calls[1] == ["tmux", "send-keys", "-t", "=milorg:.0", "Enter"]
+        assert json.loads(result)["enter_pressed"] is True
+
+    async def test_skips_enter_when_press_enter_false(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "", 0)]
+        result = await server.tmux_send_prompt(
+            prompt="echo hi", session="milorg", pane=0, press_enter=False
+        )
+
+        assert len(fake_run.calls) == 1
+        assert fake_run.calls[0][-1] == "echo hi"
+        assert "Enter" not in fake_run.calls[0]
+        assert json.loads(result)["enter_pressed"] is False
+
+    async def test_send_failure_returns_json_error_with_hint(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "no such pane", 1)]
+        result = await server.tmux_send_prompt(
+            prompt="echo hi", session="milorg", pane=0
+        )
+
+        payload = json.loads(result)
+        assert "tmux send-keys failed" in payload["error"]
+        assert "tmux_list_sessions" in payload["hint"]
+
+    async def test_enter_failure_after_literal_success(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "", 0), ("", "Enter failed", 1)]
+        result = await server.tmux_send_prompt(
+            prompt="echo hi", session="milorg", pane=0
+        )
+
+        payload = json.loads(result)
+        assert "Enter failed" in payload["error"]
+
+
+# ── tmux_list_sessions ───────────────────────────────────────────────────────
+
+
+class TestListSessions:
+    async def test_success_returns_lines(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [
+            ("milorg (1 windows, created X)\nbancs_blog (2 windows, created Y)\n", "", 0)
+        ]
+        result = await server.tmux_list_sessions()
+
+        payload = json.loads(result)
+        assert len(payload["sessions"]) == 2
+        assert "milorg" in payload["sessions"][0]
+
+    async def test_failure_returns_json_error_with_hint(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "no server running on /tmp/tmux-1000/default", 1)]
+        result = await server.tmux_list_sessions()
+
+        payload = json.loads(result)
+        assert "tmux list-sessions failed" in payload["error"]
+        assert "No tmux server running" in payload["hint"]
+
+
+# ── _resolve_session ─────────────────────────────────────────────────────────
+
+
+class TestResolveSession:
+    def test_explicit_session_passes_through(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        name, err = server._resolve_session("bancs_blog")
+        assert name == "bancs_blog"
+        assert err is None
+        # No subprocess call needed when session is explicit
+        assert fake_run.calls == []
+
+    def test_auto_picks_single_session(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("only_one\n", "", 0)]
+        name, err = server._resolve_session(None)
+        assert name == "only_one"
+        assert err is None
+
+    def test_multiple_sessions_returns_error_with_list(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("a\nb\nc\n", "", 0)]
+        name, err = server._resolve_session(None)
+        assert name is None
+        assert err is not None
+        payload = json.loads(err)
+        assert payload["available_sessions"] == ["a", "b", "c"]
+        assert "session argument required" in payload["error"]
+
+    def test_no_sessions_returns_error(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "", 0)]
+        name, err = server._resolve_session(None)
+        assert name is None
+        assert json.loads(err)["error"] == "no tmux sessions running"
+
+    def test_list_failure_surfaces(self, fake_run: FakeRun) -> None:
+        from tmux_mcp import server
+
+        fake_run._scripts = [("", "connection refused", 1)]
+        name, err = server._resolve_session(None)
+        assert name is None
+        payload = json.loads(err)
+        assert "tmux list-sessions failed" in payload["error"]
+
+
+# ── Claude Chat compat unwrap ────────────────────────────────────────────────
+
+
+class TestUnwrapChatArguments:
+    def test_unwraps_the_exact_broken_shape(self) -> None:
+        from tmux_mcp.server import _unwrap_chat_arguments
+
+        msg = {
+            "method": "tools/call",
+            "params": {
+                "name": "tmux_get_summary",
+                "arguments": {"params": '{"session": "bancs_blog", "lines": 80}'},
+            },
+        }
+        assert _unwrap_chat_arguments(msg) is True
+        assert msg["params"]["arguments"] == {"session": "bancs_blog", "lines": 80}
+
+    def test_leaves_well_formed_arguments_alone(self) -> None:
+        from tmux_mcp.server import _unwrap_chat_arguments
+
+        msg = {
+            "method": "tools/call",
+            "params": {
+                "name": "tmux_get_summary",
+                "arguments": {"session": "bancs_blog", "lines": 80},
+            },
+        }
+        before = dict(msg["params"]["arguments"])
+        assert _unwrap_chat_arguments(msg) is False
+        assert msg["params"]["arguments"] == before
+
+    def test_ignores_non_tools_call_methods(self) -> None:
+        from tmux_mcp.server import _unwrap_chat_arguments
+
+        msg = {
+            "method": "tools/list",
+            "params": {"arguments": {"params": '{"x": 1}'}},
+        }
+        assert _unwrap_chat_arguments(msg) is False
+
+    def test_ignores_params_key_when_other_keys_present(self) -> None:
+        from tmux_mcp.server import _unwrap_chat_arguments
+
+        msg = {
+            "method": "tools/call",
+            "params": {
+                "name": "x",
+                "arguments": {"params": '{"x": 1}', "other": "keep"},
+            },
+        }
+        # strict shape: arguments must be exactly {"params": "<json>"}
+        assert _unwrap_chat_arguments(msg) is False
+
+    def test_ignores_invalid_inner_json(self) -> None:
+        from tmux_mcp.server import _unwrap_chat_arguments
+
+        msg = {
+            "method": "tools/call",
+            "params": {"name": "x", "arguments": {"params": "not json {"}},
+        }
+        assert _unwrap_chat_arguments(msg) is False

--- a/uv.lock
+++ b/uv.lock
@@ -225,6 +225,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -301,6 +310,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -418,6 +445,34 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -616,6 +671,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -629,7 +686,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.8" }]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.8" },
+]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
Closes #2

## Summary

- `pytest` + `pytest-asyncio` added under `[dependency-groups].dev`; `asyncio_mode=auto` in `[tool.pytest.ini_options]`
- `tests/conftest.py` autouse fixture: temp `TMUX_MCP_STATE_DIR`, dummy OAuth env vars, purges cached `tmux_mcp.auth` / `.server` imports — no writes to `~/.config`, no network, no real tmux
- `tests/test_auth.py` (21 tests): allowlist + case-insensitivity, empty-list / `http://` URL rejection, authorize → `/oauth/github/callback` round-trip, auth-code expiry / single-use / wrong-client isolation, access vs refresh JWT separation + mutual rejection, refresh exchange preserving `sub` + `resource`, pending-auth GC, DCR `register_client` (mints missing `client_id`, mints secret for `client_secret_basic`, preserves preset ids, `get_client` round-trip)
- `tests/test_server.py` (18 tests): exact tmux argv for `tmux_get_summary` / `tmux_send_prompt` (incl. `=session:.pane` and `-l`), conditional Enter keystroke, JSON error + `hint` shape on non-zero exits, `tmux_list_sessions` success + error, all 5 branches of `_resolve_session`, strict `_unwrap_chat_arguments` shape matching (Chat-compat shim)

## Test plan

- [x] \`uv run pytest\` → 39 passed, < 3s
- [x] \`uv run ruff check\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)