### PR TITLE
feat: add IP whitelist and ban middleware

### DIFF
--- a/src/tmux_mcp/ratelimit.py
+++ b/src/tmux_mcp/ratelimit.py
@@ -1,0 +1,200 @@
+"""Pure-ASGI IP-based rate-limiting middleware.
+
+Two persistent lists in the state directory:
+
+- ``whitelist.txt`` — IPs that have successfully authenticated at least once
+  (observed by a 2xx response to a request carrying ``Authorization: Bearer``).
+  Whitelisted IPs bypass all checks. Populated lazily on first successful auth.
+
+- ``banned.txt`` — IPs that triggered a freeze. Whitelist is checked first, so
+  once an IP is whitelisted it cannot be banned. Bans are permanent; manual
+  unban is ``edit file + restart``.
+
+Freeze triggers:
+
+- A single 404 response (scanner signal — no legit client hits unknown paths).
+- More than ``threshold`` 401/403 responses in a ``window`` sliding window.
+
+Pure ASGI (not ``BaseHTTPMiddleware``) to match the other middlewares in this
+project — ``BaseHTTPMiddleware`` buffers bodies and breaks FastMCP's SSE
+streaming.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from pathlib import Path
+from threading import Lock
+from typing import Iterable
+
+
+logger = logging.getLogger("tmux_mcp.ratelimit")
+
+
+def _load_ip_file(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    ips: set[str] = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            ips.add(line)
+    return ips
+
+
+def _append_ip(path: Path, ip: str) -> None:
+    existed = path.exists()
+    with path.open("a") as f:
+        f.write(ip + "\n")
+    if not existed:
+        path.chmod(0o600)
+
+
+def _client_ip(scope: dict) -> str | None:
+    for name, value in scope.get("headers") or []:
+        if name == b"x-forwarded-for":
+            first = value.decode("latin-1").split(",")[0].strip()
+            if first:
+                return first
+    client = scope.get("client")
+    if client:
+        return client[0]
+    return None
+
+
+class RateLimitMiddleware:
+    """Pure-ASGI middleware enforcing IP whitelist / freeze rules."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        whitelist_path: Path,
+        banned_path: Path,
+        window_seconds: float = 10.0,
+        threshold: int = 10,
+    ):
+        self.app = app
+        self.whitelist_path = whitelist_path
+        self.banned_path = banned_path
+        self.window_seconds = window_seconds
+        self.threshold = threshold
+
+        self._whitelist: set[str] = _load_ip_file(whitelist_path)
+        self._banned: set[str] = _load_ip_file(banned_path)
+        self._auth_failures: dict[str, deque[float]] = {}
+        self._lock = Lock()
+
+        logger.info(
+            "rate-limit loaded: whitelist=%d banned=%d window=%.1fs threshold=%d",
+            len(self._whitelist),
+            len(self._banned),
+            window_seconds,
+            threshold,
+        )
+
+    # ── Public hooks (used by tests) ────────────────────────────────────────
+
+    def whitelist(self) -> Iterable[str]:
+        return frozenset(self._whitelist)
+
+    def banned(self) -> Iterable[str]:
+        return frozenset(self._banned)
+
+    # ── ASGI entry point ────────────────────────────────────────────────────
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        ip = _client_ip(scope)
+        if ip is None:
+            await self.app(scope, receive, send)
+            return
+
+        if ip in self._whitelist:
+            await self.app(scope, receive, send)
+            return
+
+        if ip in self._banned:
+            await self._send_forbidden(send)
+            return
+
+        has_bearer = any(
+            name == b"authorization" and value.lower().startswith(b"bearer ")
+            for name, value in (scope.get("headers") or [])
+        )
+
+        status_holder: dict[str, int] = {}
+
+        async def wrapped_send(message):
+            if message["type"] == "http.response.start":
+                status_holder["status"] = int(message["status"])
+            await send(message)
+
+        await self.app(scope, receive, wrapped_send)
+
+        status = status_holder.get("status")
+        if status is None:
+            return
+
+        if status == 404:
+            self._ban(ip, reason="404")
+            return
+
+        if status in (401, 403):
+            self._record_auth_failure(ip)
+            return
+
+        if 200 <= status < 300 and has_bearer:
+            self._whitelist_ip(ip)
+
+    # ── State mutations ─────────────────────────────────────────────────────
+
+    def _whitelist_ip(self, ip: str) -> None:
+        with self._lock:
+            if ip in self._whitelist:
+                return
+            self._whitelist.add(ip)
+            self._auth_failures.pop(ip, None)
+        _append_ip(self.whitelist_path, ip)
+        logger.info("whitelisted ip=%s (authenticated)", ip)
+
+    def _ban(self, ip: str, *, reason: str) -> None:
+        with self._lock:
+            if ip in self._banned:
+                return
+            self._banned.add(ip)
+            self._auth_failures.pop(ip, None)
+        _append_ip(self.banned_path, ip)
+        logger.warning("banned ip=%s reason=%s", ip, reason)
+
+    def _record_auth_failure(self, ip: str) -> None:
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+        should_ban = False
+        with self._lock:
+            dq = self._auth_failures.setdefault(ip, deque())
+            dq.append(now)
+            while dq and dq[0] < cutoff:
+                dq.popleft()
+            if len(dq) > self.threshold:
+                should_ban = True
+        if should_ban:
+            self._ban(ip, reason=f"auth-fail>{self.threshold}/{self.window_seconds}s")
+
+    # ── Reject path ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    async def _send_forbidden(send) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 429,
+                "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"banned\n"})

--- a/src/tmux_mcp/server.py
+++ b/src/tmux_mcp/server.py
@@ -33,7 +33,8 @@ from pydantic import AnyHttpUrl, Field
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, RedirectResponse
 
-from tmux_mcp.auth import GithubOAuthProvider
+from tmux_mcp.auth import STATE_DIR, GithubOAuthProvider
+from tmux_mcp.ratelimit import RateLimitMiddleware
 
 # Load .env from CWD or project root before any env reads.
 load_dotenv()
@@ -56,6 +57,10 @@ CLAUDE_CHAT_COMPAT = os.environ.get("TMUX_MCP_CLAUDE_CHAT_COMPAT", "1").lower() 
     "true",
     "yes",
 )
+RATELIMIT_WINDOW_SECONDS = float(
+    os.environ.get("TMUX_MCP_RATELIMIT_WINDOW_SECONDS", "10")
+)
+RATELIMIT_THRESHOLD = int(os.environ.get("TMUX_MCP_RATELIMIT_THRESHOLD", "10"))
 
 PUBLIC_URL = os.environ.get("TMUX_MCP_PUBLIC_URL", "").rstrip("/")
 GH_CLIENT_ID = os.environ.get("TMUX_MCP_GITHUB_CLIENT_ID", "")
@@ -585,6 +590,14 @@ def main() -> None:
         print("Request debug logging ENABLED (TMUX_MCP_DEBUG_REQUESTS=1)")
     if not CLAUDE_CHAT_COMPAT:
         print("Claude Chat compat shim DISABLED (TMUX_MCP_CLAUDE_CHAT_COMPAT=0)")
+    logging.getLogger("tmux_mcp.ratelimit").setLevel(logging.INFO)
+    app.add_middleware(
+        RateLimitMiddleware,
+        whitelist_path=STATE_DIR / "whitelist.txt",
+        banned_path=STATE_DIR / "banned.txt",
+        window_seconds=RATELIMIT_WINDOW_SECONDS,
+        threshold=RATELIMIT_THRESHOLD,
+    )
 
     config = uvicorn.Config(
         app, host=host, port=PORT, log_level=mcp.settings.log_level.lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,14 @@ from pathlib import Path
 
 import pytest
 
+# Set required env vars at module import so pytest collection can safely import
+# tmux_mcp.server (which raises SystemExit on missing env). Individual tests
+# can still override via monkeypatch.setenv.
+os.environ.setdefault("TMUX_MCP_PUBLIC_URL", "https://test.example")
+os.environ.setdefault("TMUX_MCP_GITHUB_CLIENT_ID", "gh-client-id")
+os.environ.setdefault("TMUX_MCP_GITHUB_CLIENT_SECRET", "gh-client-secret")
+os.environ.setdefault("TMUX_MCP_ALLOWED_GITHUB_USERS", "alice,bob")
+
 
 @pytest.fixture(autouse=True)
 def _isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,160 @@
+"""Tests for the RateLimitMiddleware.
+
+Exercises the middleware directly against a scripted ASGI inner app so we can
+assert whitelist, banned, 404-instant-freeze, auth-failure threshold, and the
+persistence files without spinning up a real server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from tmux_mcp.ratelimit import RateLimitMiddleware
+
+
+def make_inner(status: int):
+    async def inner(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    return inner
+
+
+def make_scope(ip: str, *, path: str = "/mcp", headers=None):
+    hdrs = list(headers or [])
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": hdrs,
+        "client": (ip, 12345),
+    }
+
+
+async def drive(mw, scope):
+    received = []
+
+    async def send(message):
+        received.append(message)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await mw(scope, receive, send)
+    return received
+
+
+@pytest.fixture
+def paths(tmp_path: Path) -> tuple[Path, Path]:
+    return tmp_path / "whitelist.txt", tmp_path / "banned.txt"
+
+
+def test_404_bans_instantly(paths):
+    wl, bl = paths
+    mw = RateLimitMiddleware(
+        make_inner(404), whitelist_path=wl, banned_path=bl, threshold=10
+    )
+    asyncio.run(drive(mw, make_scope("1.2.3.4")))
+    assert "1.2.3.4" in mw.banned()
+    assert bl.read_text().splitlines() == ["1.2.3.4"]
+
+
+def test_banned_ip_gets_429_without_reaching_inner(paths):
+    wl, bl = paths
+    bl.write_text("9.9.9.9\n")
+    hits = 0
+
+    async def inner(scope, receive, send):
+        nonlocal hits
+        hits += 1
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    mw = RateLimitMiddleware(inner, whitelist_path=wl, banned_path=bl)
+    received = asyncio.run(drive(mw, make_scope("9.9.9.9")))
+    assert hits == 0
+    assert received[0]["status"] == 429
+
+
+def test_whitelist_bypasses_404_ban(paths):
+    wl, bl = paths
+    wl.write_text("5.5.5.5\n")
+    mw = RateLimitMiddleware(make_inner(404), whitelist_path=wl, banned_path=bl)
+    asyncio.run(drive(mw, make_scope("5.5.5.5")))
+    assert "5.5.5.5" not in mw.banned()
+
+
+def test_auth_failures_threshold_freezes(paths):
+    wl, bl = paths
+    mw = RateLimitMiddleware(
+        make_inner(401), whitelist_path=wl, banned_path=bl, threshold=3
+    )
+    for _ in range(3):
+        asyncio.run(drive(mw, make_scope("7.7.7.7")))
+    assert "7.7.7.7" not in mw.banned()
+    asyncio.run(drive(mw, make_scope("7.7.7.7")))
+    assert "7.7.7.7" in mw.banned()
+
+
+def test_auth_failures_outside_window_dont_count(paths, monkeypatch):
+    wl, bl = paths
+    mw = RateLimitMiddleware(
+        make_inner(401),
+        whitelist_path=wl,
+        banned_path=bl,
+        threshold=3,
+        window_seconds=10,
+    )
+    t = [1000.0]
+    monkeypatch.setattr("tmux_mcp.ratelimit.time.monotonic", lambda: t[0], raising=True)
+    for _ in range(3):
+        asyncio.run(drive(mw, make_scope("8.8.8.8")))
+    t[0] += 20
+    asyncio.run(drive(mw, make_scope("8.8.8.8")))
+    assert "8.8.8.8" not in mw.banned()
+
+
+def test_successful_auth_whitelists_ip(paths):
+    wl, bl = paths
+    mw = RateLimitMiddleware(make_inner(200), whitelist_path=wl, banned_path=bl)
+    scope = make_scope("4.4.4.4", headers=[(b"authorization", b"Bearer xyz")])
+    asyncio.run(drive(mw, scope))
+    assert "4.4.4.4" in mw.whitelist()
+    assert wl.read_text().splitlines() == ["4.4.4.4"]
+
+
+def test_200_without_bearer_does_not_whitelist(paths):
+    wl, bl = paths
+    mw = RateLimitMiddleware(make_inner(200), whitelist_path=wl, banned_path=bl)
+    asyncio.run(drive(mw, make_scope("3.3.3.3")))
+    assert "3.3.3.3" not in mw.whitelist()
+
+
+def test_x_forwarded_for_is_honored(paths):
+    wl, bl = paths
+    mw = RateLimitMiddleware(make_inner(404), whitelist_path=wl, banned_path=bl)
+    scope = make_scope(
+        "127.0.0.1",
+        headers=[(b"x-forwarded-for", b"203.0.113.7, 10.0.0.1")],
+    )
+    asyncio.run(drive(mw, scope))
+    assert "203.0.113.7" in mw.banned()
+    assert "127.0.0.1" not in mw.banned()
+
+
+def test_startup_loads_existing_files(paths):
+    wl, bl = paths
+    wl.write_text("1.1.1.1\n2.2.2.2\n")
+    bl.write_text("6.6.6.6\n")
+    mw = RateLimitMiddleware(make_inner(200), whitelist_path=wl, banned_path=bl)
+    assert mw.whitelist() == frozenset({"1.1.1.1", "2.2.2.2"})
+    assert mw.banned() == frozenset({"6.6.6.6"})


### PR DESCRIPTION
Closes #1

## Summary

- Pure-ASGI middleware; matches existing `ClaudeChatCompatMiddleware` / `RequestDebugMiddleware` pattern (Starlette's `BaseHTTPMiddleware` breaks FastMCP's SSE streaming)
- Two persistent files in `STATE_DIR` (`~/.config/tmux-mcp`), mode 600, one IP per line, append-only:
  - `whitelist.txt` — populated on `Authorization: Bearer` + 2xx response
  - `banned.txt` — populated on 404 (instant) or >threshold 401/403 in a sliding window
- Whitelisted IPs bypass all checks. Banned IPs get 429 without reaching the inner app. No TTL: both lists are permanent (manual unban = edit file + restart)
- Client IP source: `X-Forwarded-For` first hop if present (tailscale serve sets it), else `scope["client"]`
- Two env knobs: `TMUX_MCP_RATELIMIT_WINDOW_SECONDS` (10), `TMUX_MCP_RATELIMIT_THRESHOLD` (10). Always enabled — security, not a feature flag
- 9 new tests (`tests/test_ratelimit.py`)

## Test plan

- [x] CI green on this PR (48 tests total)
- [x] Deploy, verify first authenticated request adds IP to \`~/.config/tmux-mcp/whitelist.txt\`
- [x] Verify an unauth'd 404 hit lands in \`~/.config/tmux-mcp/banned.txt\` and subsequent requests from that IP return 429
- [x] Confirm tailscale-served deployment uses \`X-Forwarded-For\` IP, not \`127.0.0.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)