### PR TITLE
feat(shells): add repo-tmux zsh helper for per-repo tmux sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ just re-auth, which is quick since GitHub remembers the authorization.
 └── jwt-key.pem    # RSA private key for signing access tokens (mode 600)
 ```
 
+## Shell integrations
+
+Optional shell helpers that pair well with `tmux-mcp` — e.g. `repo-tmux` for auto-attaching to a per-repo tmux session when you open a terminal. See [`tools/shells/`](tools/shells/).
+
 ## Development
 
 ```sh

--- a/tools/shells/README.md
+++ b/tools/shells/README.md
@@ -1,0 +1,90 @@
+# Shell integrations
+
+Shell helpers that pair well with `tmux-mcp`. Ship one per shell; behavior is identical across implementations so you get the same UX whether you're in zsh, bash, fish, or anything else contributors add.
+
+Currently shipped:
+
+| Shell | File | Status |
+|-------|------|--------|
+| zsh   | [zsh/repo-tmux.zsh](zsh/repo-tmux.zsh) | ✅ |
+| bash  | — | PRs welcome |
+| fish  | — | PRs welcome |
+
+## What `repo-tmux` does
+
+Opens a fresh terminal inside a git repo and you land in a tmux session for that repo — either attaching to an existing one that nobody else is using, or creating a new one with a memorable name.
+
+- **Worktree-aware.** All worktrees of the same repo share one session name. Open three worktrees in three terminals, they all land in the same tmux session.
+- **Never steals.** Only attaches to sessions with no clients. If every session for the repo is already attached, creates a new one.
+- **Memorable names.** Extra sessions are suffixed with words that all mean "ready" in different languages (see below). Override with your own list if you prefer.
+- **Universal.** Any terminal emulator, any trigger — not VS Code-specific. Also fires when you SSH into a host and land in a git repo (bonus: survives disconnect).
+
+## Requirements
+
+| Tool | Minimum version | Why |
+|------|-----------------|-----|
+| `tmux` | any recent (≥ 2.0) | it's what we're driving |
+| `git`  | 2.31 (March 2021) | uses `--path-format=absolute` on `git rev-parse`, which landed in 2.31 |
+| `zsh`  | 5.0+ | the zsh implementation uses `typeset -gra` and `${=var}` splitting |
+
+POSIX tools (`awk`, `dirname`, `basename`) are also used but are guaranteed to exist on any Unix-like system. No other dependencies — no `fzf`, no `jq`, no Python, no Node.
+
+Other shell ports (bash, fish, etc.) will have their own version constraints; contributors should document them in the same format.
+
+## Install (zsh)
+
+```zsh
+# Clone or download tmux-mcp somewhere, then:
+source /path/to/tmux-mcp/tools/shells/zsh/repo-tmux.zsh
+```
+
+Add that line to the bottom of `~/.zshrc`. Open a new terminal inside any git repo and you'll land in a tmux session named after the repo.
+
+To run the resolver manually (e.g. after setting an env var mid-session):
+
+```zsh
+repo-tmux
+```
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `TMUX_SESSION` | Force a specific session name. Attaches if it exists and is unattached; creates it if not; fails if already attached. |
+| `REPO_TMUX_SKIP` | If set to anything, the startup hook doesn't auto-run. Useful for one-off terminals where you don't want tmux. |
+| `REPO_TMUX_SUFFIXES` | Space-separated override for the default suffix list. |
+
+VS Code users: both `TMUX_SESSION` and `REPO_TMUX_SKIP` can be set per-workspace via `terminal.integrated.env.linux` (or `.osx` / `.windows`) in `.vscode/settings.json`.
+
+## The default suffix list
+
+Sessions are allocated in this order:
+
+1. `<repo>`
+2. `<repo>-paratus` *(Latin)*
+3. `<repo>-klar` *(Norwegian, Swedish, Danish, German)*
+4. `<repo>-listo` *(Spanish)*
+5. `<repo>-pronto` *(Italian)*
+6. `<repo>-bereit` *(German)*
+7. `<repo>-valmis` *(Finnish)*
+
+All mean "ready." The default is opinionated but overridable — if you'd rather use NATO, Norse gods, Greek letters, or your pets' names, set `REPO_TMUX_SUFFIXES`:
+
+```zsh
+export REPO_TMUX_SUFFIXES="odin thor loki freya tyr heimdall"
+```
+
+Seven sessions per repo (base + six suffixes) is more than any human can juggle at once, so hitting the limit usually means you want to clean up rather than add more. When the list is exhausted, `repo-tmux` refuses to create and points you at how to add more.
+
+## Shared spec (for contributors)
+
+Any bash, fish, nu, etc. port should behave identically to the zsh version:
+
+- Same env var names: `TMUX_SESSION`, `REPO_TMUX_SKIP`, `REPO_TMUX_SUFFIXES`.
+- Same gates: interactive shell + not already in tmux (`$TMUX` empty) + inside a git worktree + not opted out.
+- Same session-naming rules: `<repo>` base, then the suffix list in order.
+- Same worktree resolution: `git rev-parse --path-format=absolute --git-common-dir` → parent dir → `basename`. (Standard `git rev-parse --show-toplevel` returns the *worktree* path from inside a worktree, which gives per-worktree session names — not what we want.)
+- Same allocation policy: attach to first unattached match; create next free candidate; hard-stop when exhausted.
+- Same exhaustion error messages (default list vs. custom list — the advice differs).
+
+Open a PR adding `tools/shells/<shell>/repo-tmux.<ext>` and updating the table above. The zsh file is the reference implementation — port its behavior, not its syntax.

--- a/tools/shells/zsh/repo-tmux.zsh
+++ b/tools/shells/zsh/repo-tmux.zsh
@@ -1,0 +1,89 @@
+# repo-tmux — attach to an unattached tmux session for the current repo,
+# or create a new one. Worktree-aware: all worktrees of a repo share one
+# session name.
+#
+# Install: source this file from ~/.zshrc.
+#
+# Environment variables:
+#   TMUX_SESSION         Force a specific session name (skips resolution).
+#   REPO_TMUX_SKIP       If set, the startup hook does not auto-run.
+#   REPO_TMUX_SUFFIXES   Space-separated override for the default suffix list.
+#
+# Default suffixes mean "ready" in six languages — Latin, Norwegian, Spanish,
+# Italian, German, Finnish. Short, ASCII, distinct-sounding.
+
+typeset -gra REPO_TMUX_DEFAULT_SUFFIXES=(paratus klar listo pronto bereit valmis)
+
+repo-tmux() {
+  [[ -n "${TMUX:-}" ]] && return 0
+  command -v tmux >/dev/null || return 0
+
+  local sessions
+  sessions=$(tmux list-sessions -F '#{session_name} #{session_attached}' 2>/dev/null)
+
+  # Explicit override via TMUX_SESSION.
+  if [[ -n "${TMUX_SESSION:-}" ]]; then
+    local target="$TMUX_SESSION" st
+    st=$(awk -v n="$target" '$1 == n { print $2; exit }' <<< "$sessions")
+    if [[ "$st" == "0" ]]; then
+      exec tmux attach -t "$target"
+    elif [[ -z "$st" ]]; then
+      exec tmux new-session -s "$target"
+    else
+      print -u2 "repo-tmux: session '$target' is already attached."
+      return 1
+    fi
+  fi
+
+  # Resolve the main repo root from inside any worktree.
+  local common_dir repo_root repo
+  common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 0
+  repo_root=$(dirname "$common_dir")
+  repo=$(basename "$repo_root")
+
+  # Pick suffix list — custom if provided, default otherwise.
+  local -a suffixes
+  local is_custom=0
+  if [[ -n "${REPO_TMUX_SUFFIXES:-}" ]]; then
+    suffixes=(${=REPO_TMUX_SUFFIXES})
+    is_custom=1
+  else
+    suffixes=("${REPO_TMUX_DEFAULT_SUFFIXES[@]}")
+  fi
+
+  # Candidates in allocation order: base repo, then each suffix.
+  local -a candidates=("$repo")
+  local s
+  for s in "${suffixes[@]}"; do
+    candidates+=("${repo}-${s}")
+  done
+
+  # Attach to the first unattached existing match.
+  local name st
+  for name in "${candidates[@]}"; do
+    st=$(awk -v n="$name" '$1 == n { print $2; exit }' <<< "$sessions")
+    [[ "$st" == "0" ]] && exec tmux attach -t "$name"
+  done
+
+  # Otherwise create the first candidate that doesn't exist yet.
+  for name in "${candidates[@]}"; do
+    st=$(awk -v n="$name" '$1 == n { print $2; exit }' <<< "$sessions")
+    [[ -z "$st" ]] && exec tmux new-session -s "$name"
+  done
+
+  # Exhausted — all candidates exist and all are attached.
+  if (( is_custom )); then
+    print -u2 "All sessions are attached and your REPO_TMUX_SUFFIXES list is full."
+    print -u2 "Add more names to continue: REPO_TMUX_SUFFIXES=\"foo bar baz qux\""
+  else
+    print -u2 "All sessions are attached. If you need more, define your own list:"
+    print -u2 '  export REPO_TMUX_SUFFIXES="foo bar baz"'
+  fi
+  return 1
+}
+
+# Auto-run for fresh interactive shells inside a git repo.
+if [[ -o interactive && -z "${TMUX:-}" && -z "${REPO_TMUX_SKIP:-}" ]] \
+   && git -C "$PWD" rev-parse --git-dir >/dev/null 2>&1; then
+  repo-tmux
+fi


### PR DESCRIPTION
Closes #9

## Summary

- New `tools/shells/` section, starting with a zsh implementation of `repo-tmux`
- Attaches fresh terminals to an unattached tmux session for the current repo (worktree-aware: all worktrees share one session name via `git --git-common-dir`)
- Never steals attached sessions — allocates the next free name from the default suffix list: `paratus`, `klar`, `listo`, `pronto`, `bereit`, `valmis` (all mean "ready" in six languages)
- Escape hatches: `TMUX_SESSION` (force name), `REPO_TMUX_SKIP` (opt out), `REPO_TMUX_SUFFIXES` (override the suffix list with your own space-separated words)
- Context-aware error messages when the suffix list is exhausted — default users get "define your own list", custom users get "add more names"
- `tools/shells/README.md` documents install, requirements (tmux, git ≥ 2.31, zsh 5.0+), and a shared spec so bash/fish/etc ports stay behavior-compatible
- Top-level `README.md` links to `tools/shells/`
- No behavior change to the MCP server itself

## Test plan

- [x] Source the zsh file into \`~/.zshrc\`; open a fresh terminal inside tmux-mcp → land in a tmux session named \`tmux-mcp\`
- [x] Open a second terminal in the same repo while the first is attached → should create \`tmux-mcp-paratus\`
- [x] Set \`REPO_TMUX_SKIP=1\` in a terminal and open it in a repo → plain shell, no tmux
- [x] Set \`TMUX_SESSION=foo\` and open a terminal → lands in session \`foo\` regardless of repo
- [x] Open a terminal in a non-git directory (e.g. \`~/\`) → plain shell, no tmux
- [x] Exhaust the default list (7 concurrent sessions) → error message points at \`REPO_TMUX_SUFFIXES\` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)