### PR TITLE
feat(ratelimit): log banned IP 429 responses to pending/

### DIFF
--- a/src/tmux_mcp/ratelimit.py
+++ b/src/tmux_mcp/ratelimit.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import deque
+from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
 from typing import Iterable
@@ -73,12 +74,14 @@ class RateLimitMiddleware:
         *,
         whitelist_path: Path,
         banned_path: Path,
+        pending_log_dir: Path | None = None,
         window_seconds: float = 10.0,
         threshold: int = 10,
     ):
         self.app = app
         self.whitelist_path = whitelist_path
         self.banned_path = banned_path
+        self.pending_log_dir = pending_log_dir
         self.window_seconds = window_seconds
         self.threshold = threshold
 
@@ -88,11 +91,12 @@ class RateLimitMiddleware:
         self._lock = Lock()
 
         logger.info(
-            "rate-limit loaded: whitelist=%d banned=%d window=%.1fs threshold=%d",
+            "rate-limit loaded: whitelist=%d banned=%d window=%.1fs threshold=%d log_dir=%s",
             len(self._whitelist),
             len(self._banned),
             window_seconds,
             threshold,
+            pending_log_dir or "<off>",
         )
 
     # ── Public hooks (used by tests) ────────────────────────────────────────
@@ -120,6 +124,7 @@ class RateLimitMiddleware:
             return
 
         if ip in self._banned:
+            self._log_pending(ip, scope)
             await self._send_forbidden(send)
             return
 
@@ -143,6 +148,11 @@ class RateLimitMiddleware:
 
         if status == 404:
             self._ban(ip, reason="404")
+            return
+
+        if status == 429:
+            # Inner app emitted 429 independently of the middleware reject path.
+            self._log_pending(ip, scope)
             return
 
         if status in (401, 403):
@@ -185,6 +195,26 @@ class RateLimitMiddleware:
                 should_ban = True
         if should_ban:
             self._ban(ip, reason=f"auth-fail>{self.threshold}/{self.window_seconds}s")
+
+    # ── Pending-log write (best-effort) ─────────────────────────────────────
+
+    def _log_pending(self, ip: str, scope: dict) -> None:
+        if self.pending_log_dir is None:
+            return
+        try:
+            self.pending_log_dir.mkdir(parents=True, exist_ok=True)
+            # Colons in IPv6 addresses are legal in filenames on Linux/macOS
+            # but ugly — normalize so `2001:db8::1` → `2001_db8__1.log`.
+            safe_ip = ip.replace(":", "_")
+            path = self.pending_log_dir / f"{safe_ip}.log"
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            method = scope.get("method", "?")
+            req_path = scope.get("path", "?")
+            line = f"{ts} {ip} {method} {req_path} 429\n"
+            with path.open("a") as f:
+                f.write(line)
+        except OSError as e:
+            logger.warning("pending-log write failed for ip=%s: %s", ip, e)
 
     # ── Reject path ─────────────────────────────────────────────────────────
 

--- a/src/tmux_mcp/server.py
+++ b/src/tmux_mcp/server.py
@@ -21,6 +21,7 @@ import logging
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 from dotenv import load_dotenv
 from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
@@ -61,6 +62,7 @@ RATELIMIT_WINDOW_SECONDS = float(
     os.environ.get("TMUX_MCP_RATELIMIT_WINDOW_SECONDS", "10")
 )
 RATELIMIT_THRESHOLD = int(os.environ.get("TMUX_MCP_RATELIMIT_THRESHOLD", "10"))
+LOG_DIR = os.environ.get("TMUX_MCP_LOG_DIR", "./logs")
 
 PUBLIC_URL = os.environ.get("TMUX_MCP_PUBLIC_URL", "").rstrip("/")
 GH_CLIENT_ID = os.environ.get("TMUX_MCP_GITHUB_CLIENT_ID", "")
@@ -595,6 +597,7 @@ def main() -> None:
         RateLimitMiddleware,
         whitelist_path=STATE_DIR / "whitelist.txt",
         banned_path=STATE_DIR / "banned.txt",
+        pending_log_dir=Path(LOG_DIR).expanduser() / "pending",
         window_seconds=RATELIMIT_WINDOW_SECONDS,
         threshold=RATELIMIT_THRESHOLD,
     )

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -58,6 +58,11 @@ def paths(tmp_path: Path) -> tuple[Path, Path]:
     return tmp_path / "whitelist.txt", tmp_path / "banned.txt"
 
 
+@pytest.fixture
+def pending_dir(tmp_path: Path) -> Path:
+    return tmp_path / "logs" / "pending"
+
+
 def test_404_bans_instantly(paths):
     wl, bl = paths
     mw = RateLimitMiddleware(
@@ -158,3 +163,122 @@ def test_startup_loads_existing_files(paths):
     mw = RateLimitMiddleware(make_inner(200), whitelist_path=wl, banned_path=bl)
     assert mw.whitelist() == frozenset({"1.1.1.1", "2.2.2.2"})
     assert mw.banned() == frozenset({"6.6.6.6"})
+
+
+# ── Pending-log (abuse pipeline Part 1) ─────────────────────────────────────
+
+
+def test_banned_ip_request_is_logged_to_pending(paths, pending_dir):
+    wl, bl = paths
+    bl.write_text("9.9.9.9\n")
+    mw = RateLimitMiddleware(
+        make_inner(200),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=pending_dir,
+    )
+    asyncio.run(drive(mw, make_scope("9.9.9.9", path="/auth.js")))
+    log = (pending_dir / "9.9.9.9.log").read_text()
+    assert "9.9.9.9 GET /auth.js 429" in log
+
+
+def test_multiple_banned_requests_append(paths, pending_dir):
+    wl, bl = paths
+    bl.write_text("9.9.9.9\n")
+    mw = RateLimitMiddleware(
+        make_inner(200),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=pending_dir,
+    )
+    asyncio.run(drive(mw, make_scope("9.9.9.9", path="/robots.txt")))
+    asyncio.run(drive(mw, make_scope("9.9.9.9", path="/bot-connect.js")))
+    lines = (pending_dir / "9.9.9.9.log").read_text().splitlines()
+    assert len(lines) == 2
+    assert "/robots.txt" in lines[0]
+    assert "/bot-connect.js" in lines[1]
+
+
+def test_inner_app_429_is_also_logged(paths, pending_dir):
+    wl, bl = paths
+    mw = RateLimitMiddleware(
+        make_inner(429),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=pending_dir,
+    )
+    asyncio.run(drive(mw, make_scope("7.7.7.7", path="/some/path")))
+    log = (pending_dir / "7.7.7.7.log").read_text()
+    assert "7.7.7.7 GET /some/path 429" in log
+
+
+def test_whitelisted_ip_is_never_logged(paths, pending_dir):
+    wl, bl = paths
+    wl.write_text("5.5.5.5\n")
+    mw = RateLimitMiddleware(
+        make_inner(429),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=pending_dir,
+    )
+    asyncio.run(drive(mw, make_scope("5.5.5.5")))
+    assert not pending_dir.exists() or not any(pending_dir.iterdir())
+
+
+def test_pending_dir_autocreated(paths, pending_dir):
+    wl, bl = paths
+    bl.write_text("9.9.9.9\n")
+    assert not pending_dir.exists()
+    mw = RateLimitMiddleware(
+        make_inner(200),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=pending_dir,
+    )
+    asyncio.run(drive(mw, make_scope("9.9.9.9")))
+    assert pending_dir.is_dir()
+    assert (pending_dir / "9.9.9.9.log").exists()
+
+
+def test_logging_disabled_when_no_dir(paths, tmp_path):
+    wl, bl = paths
+    bl.write_text("9.9.9.9\n")
+    mw = RateLimitMiddleware(
+        make_inner(200),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=None,
+    )
+    asyncio.run(drive(mw, make_scope("9.9.9.9")))
+    # No log dir provided, no files created anywhere.
+    assert not any(tmp_path.glob("**/*.log"))
+
+
+def test_ipv6_colons_normalized_in_filename(paths, pending_dir):
+    wl, bl = paths
+    bl.write_text("2001:db8::1\n")
+    mw = RateLimitMiddleware(
+        make_inner(200),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=pending_dir,
+    )
+    asyncio.run(drive(mw, make_scope("2001:db8::1")))
+    assert (pending_dir / "2001_db8__1.log").exists()
+
+
+def test_log_write_failure_does_not_break_request(paths, tmp_path, caplog):
+    wl, bl = paths
+    bl.write_text("9.9.9.9\n")
+    # Point log dir at an existing file so mkdir will fail.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    mw = RateLimitMiddleware(
+        make_inner(200),
+        whitelist_path=wl,
+        banned_path=bl,
+        pending_log_dir=blocker / "pending",
+    )
+    received = asyncio.run(drive(mw, make_scope("9.9.9.9")))
+    # Request still completes with 429 reject.
+    assert received[0]["status"] == 429


### PR DESCRIPTION
Closes #11 · Part of #14

## Summary

- `RateLimitMiddleware` now takes optional `pending_log_dir`; when set, every 429 response appends one line per request to `{log_dir}/{ip}.log` in raw server log format: `{RFC3339Z} {ip} {method} {path} 429`
- Covers both the middleware's own reject path (banned IPs) and any 429 emitted by the inner app
- Whitelisted IPs skip logging (they never hit 429)
- IPv6 colons normalized to underscores in filenames (`2001:db8::1` → `2001_db8__1.log`)
- Best-effort writes: IO errors emit a warning, never break the request
- New env var `TMUX_MCP_LOG_DIR` (default `./logs`) — explicitly not rooted in `STATE_DIR`; logs are operational data, separate from auth/state
- Middleware receives `{log_dir}/pending/`; Parts 2 and 3 of the umbrella (#14) will use `staged/` and `reported/` under the same root
- 8 new tests, 56 total green

## Test plan

- [x] Deploy, hit the server with unauthenticated requests, trigger a ban (one 404 is enough), then verify \`./logs/pending/{ip}.log\` exists and subsequent requests from that IP append lines
- [x] Confirm whitelisted IPs (authenticated callers) produce no log file even under heavy traffic
- [x] Set \`TMUX_MCP_LOG_DIR=/var/log/tmux-mcp\`, confirm logs land there
- [x] Trigger a 429 from the app itself (not the middleware) and confirm it's still captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)