### PR TITLE
feat(enricher): add abuse-pipeline watcher as separate process

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ just re-auth, which is quick since GitHub remembers the authorization.
 └── jwt-key.pem    # RSA private key for signing access tokens (mode 600)
 ```
 
+## Abuse-report enricher (optional)
+
+A separate process watches `{TMUX_MCP_LOG_DIR:-./logs}/pending/` for rate-limited-IP logs, enriches each file (ASN + country via RIPE Stat, AbuseIPDB category heuristics), and moves it to `staged/` once the file has been idle for 60 seconds. Run it alongside the server if you want to collect data for abuse reports:
+
+```sh
+uv run tmux-mcp-enricher
+```
+
+Runs independently of the main server — restart either without affecting the other. RIPE lookup failures are treated as non-fatal; enrichment proceeds with `unknown` fields. Planned Part 3 (upstream `send_report` MCP tool) will consume `staged/` and submit to AbuseIPDB.
+
 ## Shell integrations
 
 Optional shell helpers that pair well with `tmux-mcp` — e.g. `repo-tmux` for auto-attaching to a per-repo tmux session when you open a terminal. See [`tools/shells/`](tools/shells/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [project.scripts]
 tmux-mcp = "tmux_mcp:main"
+tmux-mcp-enricher = "tmux_mcp.enricher:main"
 
 [dependency-groups]
 dev = [

--- a/src/tmux_mcp/enricher.py
+++ b/src/tmux_mcp/enricher.py
@@ -1,0 +1,360 @@
+"""Abuse pipeline — watches ``pending/``, debounces, enriches, moves to ``staged/``.
+
+When a per-IP file under ``pending/`` has been quiet for ``quiet_seconds``
+(default 60s), enrich it with:
+
+- **ASN + holder** (via RIPE Stat ``prefix-overview``)
+- **Country** (via RIPE Stat ``geoloc``)
+- **RIR** (derived from country code — static lookup)
+- **AbuseIPDB categories** (heuristic on request paths)
+- **FirstSeen / LastSeen / RequestCount**
+
+and move it to ``staged/``. If any RIPE lookup fails, the corresponding field
+is left as ``unknown`` — enrichment never blocks the pipeline.
+
+The watcher is a pure poll loop (5s tick). No ``watchdog`` dependency, no
+inotify — keeps the code portable and testable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+from dotenv import load_dotenv
+
+
+logger = logging.getLogger("tmux_mcp.enricher")
+
+# ── RIPE Stat endpoints ─────────────────────────────────────────────────────
+
+_RIPE_BASE = "https://stat.ripe.net/data"
+_PREFIX_URL = f"{_RIPE_BASE}/prefix-overview/data.json"
+_GEOLOC_URL = f"{_RIPE_BASE}/geoloc/data.json"
+_RIPE_TIMEOUT = 5.0
+
+# ── AbuseIPDB categories ────────────────────────────────────────────────────
+
+CATEGORY_BRUTE_FORCE = 18
+CATEGORY_WEB_APP_ATTACK = 19
+CATEGORY_PORT_SCAN = 21
+
+# Regex probes for common exploit paths — web-app-attack heuristic.
+# Intentionally broad so we catch payment-form scanners, WP/phpMyAdmin probes,
+# dotfile exfil attempts, and webshell drops.
+_WEB_ATTACK_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"/wp-(login|admin|config|content)", re.I),
+    re.compile(r"/phpmyadmin", re.I),
+    re.compile(r"/\.env(\.|$)"),
+    re.compile(r"/\.(git|svn|hg|DS_Store)(/|$)"),
+    re.compile(r"/(admin|administrator|manage|console)(\.php|/|$)", re.I),
+    re.compile(r"/(shell|cmd|phpshell|r57|c99|webshell)\.(php|jsp|asp)", re.I),
+    re.compile(r"\.(bak|sql|log|env|old)$", re.I),
+    re.compile(
+        r"/(cart|checkout|payment|billing|order).*(cc|card|ccnum|cvv|cvc|expir|"
+        r"security.?code|pan)",
+        re.I,
+    ),
+    re.compile(r"/api/v\d+/admin", re.I),
+    re.compile(r"/(xmlrpc|wlwmanifest|wp-includes)", re.I),
+    re.compile(r"/config\.(json|yaml|yml|php|ini)$", re.I),
+)
+
+# Country ISO-3166 alpha-2 → RIR. Not perfect (legacy space can cross RIRs) but
+# a reasonable default for routing abuse reports. Default ARIN for anything not
+# listed.
+_COUNTRY_TO_RIR: dict[str, str] = {
+    # RIPE NCC — Europe + Middle East + Central Asia
+    **dict.fromkeys(
+        "AD AE AL AM AT AZ BA BE BG BH BY CH CY CZ DE DK EE ES FI FO FR GB GE GG "
+        "GI GR HR HU IE IL IM IQ IR IS IT JE JO KG KW KZ LB LI LT LU LV MC MD ME "
+        "MK MT NL NO OM PL PS PT QA RO RS RU SA SE SI SJ SK SM SY TJ TM TR UA UZ "
+        "VA XK YE".split(),
+        "RIPE NCC",
+    ),
+    # APNIC — Asia-Pacific
+    **dict.fromkeys(
+        "AF AS AU BD BN BT CC CK CN CX FJ FM GU HK ID IN JP KH KI KP KR LA LK MH "
+        "MM MN MO MP MV MY NC NF NP NR NU NZ PF PG PH PK PN PW SB SG TH TK TL TO "
+        "TV TW VN VU WF WS".split(),
+        "APNIC",
+    ),
+    # LACNIC — Latin America + Caribbean
+    **dict.fromkeys(
+        "AG AI AR AW BB BL BM BO BQ BR BS BZ CL CO CR CU CW DM DO EC FK GD GF GP "
+        "GT GY HN HT JM KN KY LC MF MQ MS MX NI PA PE PY SR SV SX TC TT UY VC VE "
+        "VG VI".split(),
+        "LACNIC",
+    ),
+    # AFRINIC — Africa
+    **dict.fromkeys(
+        "AO BF BI BJ BW CD CF CG CI CM CV DJ DZ EG EH ER ET GA GH GM GN GQ GW KE "
+        "KM LR LS LY MA MG ML MR MU MW MZ NA NE NG RE RW SC SD SH SL SN SO SS ST "
+        "SZ TD TG TN TZ UG YT ZA ZM ZW".split(),
+        "AFRINIC",
+    ),
+}
+
+_LINE_RE = re.compile(
+    r"^(?P<ts>\S+)\s+(?P<ip>\S+)\s+(?P<method>\S+)\s+(?P<path>\S+)\s+(?P<status>\d+)$"
+)
+
+
+# ── Public data shapes ──────────────────────────────────────────────────────
+
+
+def parse_log_line(line: str) -> dict | None:
+    m = _LINE_RE.match(line.strip())
+    return m.groupdict() if m else None
+
+
+def rir_for_country(country: str | None) -> str:
+    if not country:
+        return "unknown"
+    return _COUNTRY_TO_RIR.get(country.upper(), "ARIN")
+
+
+def report_to(rir: str) -> str:
+    """Comma-separated entity list. AbuseIPDB is always included."""
+    if rir and rir != "unknown":
+        return f"AbuseIPDB, {rir}"
+    return "AbuseIPDB"
+
+
+# ── Categorization ──────────────────────────────────────────────────────────
+
+
+def _is_web_app_attack(path: str) -> bool:
+    return any(p.search(path) for p in _WEB_ATTACK_PATTERNS)
+
+
+def detect_categories(requests: list[dict]) -> list[int]:
+    """Return AbuseIPDB category IDs triggered by this request set.
+
+    - **19 Web App Attack**: any single request hits an exploit pattern.
+    - **21 Port Scan**: ≥ 3 distinct paths (sign of broad probing).
+    - **18 Brute Force**: ≥ 5 requests to the same path.
+    """
+    cats: set[int] = set()
+    if any(_is_web_app_attack(r["path"]) for r in requests):
+        cats.add(CATEGORY_WEB_APP_ATTACK)
+
+    paths = [r["path"] for r in requests]
+    if len(set(paths)) >= 3:
+        cats.add(CATEGORY_PORT_SCAN)
+
+    if any(c >= 5 for c in Counter(paths).values()):
+        cats.add(CATEGORY_BRUTE_FORCE)
+
+    return sorted(cats)
+
+
+# ── RIPE Stat lookups ───────────────────────────────────────────────────────
+
+
+async def _ripe_lookup(client: httpx.AsyncClient, ip: str) -> dict:
+    """Query RIPE Stat for ASN + country. Returns a dict with whatever fields
+    succeeded; missing lookups leave their keys unset.
+    """
+    out: dict[str, str] = {}
+
+    async def _prefix():
+        try:
+            r = await client.get(
+                _PREFIX_URL, params={"resource": ip}, timeout=_RIPE_TIMEOUT
+            )
+            r.raise_for_status()
+            data = r.json().get("data", {})
+            asns = data.get("asns") or []
+            if asns:
+                asn = asns[0]
+                out["asn"] = f"AS{asn['asn']}"
+                holder = asn.get("holder")
+                if holder:
+                    out["asn_holder"] = holder
+        except Exception as e:  # any network / parse failure — graceful skip
+            logger.info("RIPE prefix-overview failed for %s: %s", ip, e)
+
+    async def _geo():
+        try:
+            r = await client.get(
+                _GEOLOC_URL, params={"resource": ip}, timeout=_RIPE_TIMEOUT
+            )
+            r.raise_for_status()
+            locs = r.json().get("data", {}).get("locations") or []
+            if locs:
+                country = locs[0].get("country")
+                if country:
+                    out["country"] = country.upper()
+        except Exception as e:  # any network / parse failure — graceful skip
+            logger.info("RIPE geoloc failed for %s: %s", ip, e)
+
+    await asyncio.gather(_prefix(), _geo())
+    return out
+
+
+# ── Promote one pending file ────────────────────────────────────────────────
+
+
+async def promote_file(
+    pending_path: Path,
+    staged_dir: Path,
+    client: httpx.AsyncClient,
+) -> Path | None:
+    """Read a pending file, enrich it, write the staged file, delete pending.
+
+    Returns the staged path on success, ``None`` if the file is empty or
+    malformed.
+    """
+    try:
+        lines = [ln for ln in pending_path.read_text().splitlines() if ln.strip()]
+    except OSError as e:
+        logger.warning("cannot read pending file %s: %s", pending_path, e)
+        return None
+
+    requests: list[dict] = []
+    ip: str | None = None
+    for ln in lines:
+        parsed = parse_log_line(ln)
+        if not parsed:
+            continue
+        if ip is None:
+            ip = parsed["ip"]
+        requests.append(parsed)
+
+    if not requests or ip is None:
+        logger.info("skipping empty or malformed pending file: %s", pending_path)
+        pending_path.unlink(missing_ok=True)
+        return None
+
+    ripe = await _ripe_lookup(client, ip)
+    asn = ripe.get("asn", "unknown")
+    holder = ripe.get("asn_holder")
+    asn_field = f"{asn} ({holder})" if holder else asn
+    country = ripe.get("country", "unknown")
+    rir = rir_for_country(ripe.get("country"))
+    cats = detect_categories(requests)
+    first_seen = requests[0]["ts"]
+    last_seen = requests[-1]["ts"]
+
+    staged_dir.mkdir(parents=True, exist_ok=True)
+    staged_path = staged_dir / pending_path.name
+    header = (
+        f"IP: {ip}\n"
+        f"ASN: {asn_field}\n"
+        f"Country: {country}\n"
+        f"RIR: {rir}\n"
+        f"ReportTo: {report_to(rir)}\n"
+        f"AbuseIPDB-Categories: {','.join(str(c) for c in cats) or 'none'}\n"
+        f"FirstSeen: {first_seen}\n"
+        f"LastSeen: {last_seen}\n"
+        f"RequestCount: {len(requests)}\n"
+        f"\n"
+        f"Requests:\n"
+    )
+    body = "\n".join(
+        f"{r['ts']} {r['method']} {r['path']} {r['status']}" for r in requests
+    )
+    staged_path.write_text(header + body + "\n")
+    pending_path.unlink(missing_ok=True)
+    logger.info(
+        "staged %s ip=%s requests=%d categories=%s",
+        staged_path.name,
+        ip,
+        len(requests),
+        cats,
+    )
+    return staged_path
+
+
+# ── Watcher loop ────────────────────────────────────────────────────────────
+
+
+async def run_watcher(
+    pending_dir: Path,
+    staged_dir: Path,
+    *,
+    quiet_seconds: float = 60.0,
+    tick_seconds: float = 5.0,
+    client: httpx.AsyncClient | None = None,
+) -> None:
+    """Poll ``pending_dir`` forever; promote any file idle for ``quiet_seconds``.
+
+    If ``client`` is None, an internal ``httpx.AsyncClient`` is created.
+    """
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient()
+    logger.info(
+        "enricher watcher started pending=%s staged=%s quiet=%.0fs tick=%.0fs",
+        pending_dir,
+        staged_dir,
+        quiet_seconds,
+        tick_seconds,
+    )
+    try:
+        while True:
+            try:
+                await _tick(pending_dir, staged_dir, quiet_seconds, client)
+            except Exception as e:  # defensive — never let the loop die
+                logger.warning("enricher tick failed: %s", e)
+            await asyncio.sleep(tick_seconds)
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+# ── CLI entry point ─────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    """Run the enricher as a standalone process.
+
+    Reads ``TMUX_MCP_LOG_DIR`` (default ``./logs``) and watches ``pending/``
+    forever. Runs independently of the MCP server — start it alongside via
+    systemd, supervisor, tmux, or anything else.
+    """
+    load_dotenv()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    log_root = Path(os.environ.get("TMUX_MCP_LOG_DIR", "./logs")).expanduser()
+    pending = log_root / "pending"
+    staged = log_root / "staged"
+    print(f"tmux-mcp-enricher: watching {pending} → {staged}")
+    try:
+        asyncio.run(run_watcher(pending, staged))
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+
+
+if __name__ == "__main__":
+    main()
+
+
+async def _tick(
+    pending_dir: Path,
+    staged_dir: Path,
+    quiet_seconds: float,
+    client: httpx.AsyncClient,
+) -> None:
+    if not pending_dir.is_dir():
+        return
+    now = datetime.now(timezone.utc).timestamp()
+    for entry in pending_dir.iterdir():
+        if not entry.is_file() or not entry.name.endswith(".log"):
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except FileNotFoundError:
+            continue
+        if now - mtime < quiet_seconds:
+            continue
+        await promote_file(entry, staged_dir, client)

--- a/src/tmux_mcp/server.py
+++ b/src/tmux_mcp/server.py
@@ -593,11 +593,12 @@ def main() -> None:
     if not CLAUDE_CHAT_COMPAT:
         print("Claude Chat compat shim DISABLED (TMUX_MCP_CLAUDE_CHAT_COMPAT=0)")
     logging.getLogger("tmux_mcp.ratelimit").setLevel(logging.INFO)
+    log_root = Path(LOG_DIR).expanduser()
     app.add_middleware(
         RateLimitMiddleware,
         whitelist_path=STATE_DIR / "whitelist.txt",
         banned_path=STATE_DIR / "banned.txt",
-        pending_log_dir=Path(LOG_DIR).expanduser() / "pending",
+        pending_log_dir=log_root / "pending",
         window_seconds=RATELIMIT_WINDOW_SECONDS,
         threshold=RATELIMIT_THRESHOLD,
     )

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -1,0 +1,313 @@
+"""Tests for the abuse-pipeline enricher."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tmux_mcp.enricher import (
+    CATEGORY_BRUTE_FORCE,
+    CATEGORY_PORT_SCAN,
+    CATEGORY_WEB_APP_ATTACK,
+    detect_categories,
+    parse_log_line,
+    promote_file,
+    report_to,
+    rir_for_country,
+    run_watcher,
+)
+
+
+# ── Parsing ─────────────────────────────────────────────────────────────────
+
+
+def test_parse_log_line_roundtrip():
+    parsed = parse_log_line("2026-04-23T14:07:37Z 155.2.225.177 GET /auth.js 429")
+    assert parsed == {
+        "ts": "2026-04-23T14:07:37Z",
+        "ip": "155.2.225.177",
+        "method": "GET",
+        "path": "/auth.js",
+        "status": "429",
+    }
+
+
+def test_parse_log_line_rejects_garbage():
+    assert parse_log_line("") is None
+    assert parse_log_line("not a log line") is None
+
+
+# ── RIR lookup ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "country,expected",
+    [
+        ("CH", "RIPE NCC"),
+        ("ch", "RIPE NCC"),  # case-insensitive
+        ("US", "ARIN"),
+        ("CN", "APNIC"),
+        ("BR", "LACNIC"),
+        ("ZA", "AFRINIC"),
+        ("XX", "ARIN"),  # unknown defaults to ARIN
+        ("", "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_rir_for_country(country, expected):
+    assert rir_for_country(country) == expected
+
+
+def test_report_to_always_includes_abuseipdb():
+    assert "AbuseIPDB" in report_to("RIPE NCC")
+    assert "RIPE NCC" in report_to("RIPE NCC")
+    assert report_to("unknown") == "AbuseIPDB"
+    assert report_to("") == "AbuseIPDB"
+
+
+# ── Category detection ─────────────────────────────────────────────────────
+
+
+def _req(path, method="GET"):
+    return {
+        "ts": "2026-04-23T00:00:00Z",
+        "method": method,
+        "path": path,
+        "status": "429",
+    }
+
+
+def test_web_app_attack_on_wp_login():
+    assert CATEGORY_WEB_APP_ATTACK in detect_categories([_req("/wp-login.php")])
+
+
+def test_web_app_attack_on_env_exfil():
+    assert CATEGORY_WEB_APP_ATTACK in detect_categories([_req("/.env")])
+
+
+def test_web_app_attack_on_payment_scanner():
+    # Payment-form scanner pattern — cart/checkout path carrying CC-like params.
+    cats = detect_categories([_req("/cart/checkout?ccnum=4111111111111111&cvv=123")])
+    assert CATEGORY_WEB_APP_ATTACK in cats
+
+
+def test_web_app_attack_on_webshell():
+    assert CATEGORY_WEB_APP_ATTACK in detect_categories([_req("/uploads/c99.php")])
+
+
+def test_port_scan_triggers_on_distinct_paths():
+    reqs = [_req(f"/path/{i}") for i in range(3)]
+    assert CATEGORY_PORT_SCAN in detect_categories(reqs)
+
+
+def test_port_scan_does_not_trigger_on_two_paths():
+    reqs = [_req("/a"), _req("/b")]
+    assert CATEGORY_PORT_SCAN not in detect_categories(reqs)
+
+
+def test_brute_force_triggers_on_same_path_repeated():
+    reqs = [_req("/api/login") for _ in range(5)]
+    cats = detect_categories(reqs)
+    assert CATEGORY_BRUTE_FORCE in cats
+
+
+def test_brute_force_does_not_trigger_below_threshold():
+    reqs = [_req("/api/login") for _ in range(4)]
+    assert CATEGORY_BRUTE_FORCE not in detect_categories(reqs)
+
+
+def test_categories_can_combine():
+    # 5 hits on an exploit path → 18 + 19 (and 21 needs distinct paths, so not here)
+    reqs = [_req("/wp-login.php") for _ in range(5)]
+    cats = detect_categories(reqs)
+    assert CATEGORY_WEB_APP_ATTACK in cats
+    assert CATEGORY_BRUTE_FORCE in cats
+
+
+# ── File promotion ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pending_and_staged(tmp_path: Path) -> tuple[Path, Path]:
+    pending = tmp_path / "pending"
+    staged = tmp_path / "staged"
+    pending.mkdir()
+    return pending, staged
+
+
+def _write_pending(pending: Path, ip: str, lines: list[str]) -> Path:
+    file = pending / f"{ip}.log"
+    file.write_text("\n".join(lines) + "\n")
+    return file
+
+
+def test_promote_file_writes_staged_and_removes_pending(pending_and_staged):
+    pending, staged = pending_and_staged
+    file = _write_pending(
+        pending,
+        "155.2.225.177",
+        [
+            "2026-04-23T14:07:37Z 155.2.225.177 GET /wp-login.php 429",
+            "2026-04-23T14:07:38Z 155.2.225.177 GET /wp-admin/ 429",
+            "2026-04-23T14:07:39Z 155.2.225.177 GET /.env 429",
+        ],
+    )
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=Exception("ripe offline"))
+    result = asyncio.run(promote_file(file, staged, client))
+
+    assert result is not None
+    assert not file.exists()
+    assert result.parent == staged
+    content = result.read_text()
+    assert "IP: 155.2.225.177" in content
+    assert "ASN: unknown" in content
+    assert "Country: unknown" in content
+    assert "RIR: unknown" in content
+    assert "ReportTo: AbuseIPDB" in content
+    assert "AbuseIPDB-Categories: 19,21" in content
+    assert "RequestCount: 3" in content
+    assert "FirstSeen: 2026-04-23T14:07:37Z" in content
+    assert "LastSeen: 2026-04-23T14:07:39Z" in content
+    assert "/wp-login.php 429" in content
+
+
+def test_promote_file_with_ripe_lookup_populates_asn_country(pending_and_staged):
+    pending, staged = pending_and_staged
+    file = _write_pending(
+        pending,
+        "155.2.225.177",
+        ["2026-04-23T14:07:37Z 155.2.225.177 GET /.env 429"],
+    )
+
+    # Fake RIPE Stat responses.
+    prefix_resp = AsyncMock()
+    prefix_resp.raise_for_status = lambda: None
+    prefix_resp.json = lambda: {"data": {"asns": [{"asn": 8758, "holder": "Iway AG"}]}}
+
+    geoloc_resp = AsyncMock()
+    geoloc_resp.raise_for_status = lambda: None
+    geoloc_resp.json = lambda: {"data": {"locations": [{"country": "CH"}]}}
+
+    async def fake_get(url, **_):
+        return prefix_resp if "prefix-overview" in url else geoloc_resp
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=fake_get)
+
+    result = asyncio.run(promote_file(file, staged, client))
+    content = result.read_text()
+    assert "ASN: AS8758 (Iway AG)" in content
+    assert "Country: CH" in content
+    assert "RIR: RIPE NCC" in content
+    assert "ReportTo: AbuseIPDB, RIPE NCC" in content
+
+
+def test_promote_file_empty_is_skipped(pending_and_staged):
+    pending, staged = pending_and_staged
+    file = pending / "1.2.3.4.log"
+    file.write_text("\n\n\n")  # no valid lines
+    client = AsyncMock()
+    client.get = AsyncMock()
+    result = asyncio.run(promote_file(file, staged, client))
+    assert result is None
+    assert not file.exists()
+
+
+# ── Watcher loop ────────────────────────────────────────────────────────────
+
+
+def test_watcher_promotes_quiet_file(pending_and_staged):
+    pending, staged = pending_and_staged
+    file = _write_pending(
+        pending, "9.9.9.9", ["2026-04-23T14:07:37Z 9.9.9.9 GET /a 429"]
+    )
+    # Force mtime to be old enough.
+    old = file.stat().st_mtime - 3600
+    os.utime(file, (old, old))
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=Exception("offline"))
+
+    async def run_briefly():
+        task = asyncio.create_task(
+            run_watcher(
+                pending,
+                staged,
+                quiet_seconds=60.0,
+                tick_seconds=0.01,
+                client=client,
+            )
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(run_briefly())
+    assert not file.exists()
+    assert (staged / "9.9.9.9.log").exists()
+
+
+def test_watcher_leaves_recent_file_alone(pending_and_staged):
+    pending, staged = pending_and_staged
+    file = _write_pending(
+        pending, "9.9.9.9", ["2026-04-23T14:07:37Z 9.9.9.9 GET /a 429"]
+    )
+    # mtime is now — watcher should not promote yet.
+
+    client = AsyncMock()
+    client.get = AsyncMock()
+
+    async def run_briefly():
+        task = asyncio.create_task(
+            run_watcher(
+                pending,
+                staged,
+                quiet_seconds=60.0,
+                tick_seconds=0.01,
+                client=client,
+            )
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(run_briefly())
+    assert file.exists()
+    assert not staged.exists() or not any(staged.iterdir())
+
+
+def test_watcher_handles_missing_pending_dir(tmp_path):
+    client = AsyncMock()
+    client.get = AsyncMock()
+
+    async def run_briefly():
+        task = asyncio.create_task(
+            run_watcher(
+                tmp_path / "pending-does-not-exist",
+                tmp_path / "staged",
+                quiet_seconds=60.0,
+                tick_seconds=0.01,
+                client=client,
+            )
+        )
+        await asyncio.sleep(0.03)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Should not raise.
+    asyncio.run(run_briefly())


### PR DESCRIPTION
Closes #12 · Part of #14

## Summary

- New `tmux_mcp.enricher` library + `tmux-mcp-enricher` CLI entry point
- Polls `{TMUX_MCP_LOG_DIR:-./logs}/pending/` on a 5s tick, promotes any file quiet for ≥ 60s to `staged/` with an enriched header
- RIPE Stat lookups (prefix-overview + geoloc) run in parallel; any network failure → `unknown` fields, pipeline never stalls
- Category heuristics: 18 Brute Force (5+ to same path), 19 Web App Attack (regex on WP/phpMyAdmin/dotfiles/webshells/payment scanners), 21 Port Scan (3+ distinct paths). OR-combined per IP
- **Separate process** — no coupling to the MCP server lifecycle. Filesystem is the only interface. Either can restart independently
- README documents the optional enricher
- 27 new tests, 83 total green

## Test plan

- [x] Start the server, hit unknown paths from an external IP to accumulate entries in \`./logs/pending/{ip}.log\`
- [x] Run \`uv run tmux-mcp-enricher\` in a second terminal; stop hitting the server and wait 60s — the per-IP file should move to \`./logs/staged/{ip}.log\` with RIR/categories populated
- [x] With RIPE reachable, confirm ASN + country resolve correctly (e.g. Swiss IP → RIPE NCC); with network blocked (iptables), confirm staged file still appears with \`unknown\` fields
- [x] Restart the enricher with files already in \`pending/\` — should pick them up on next tick (no lost state)
- [x] Verify the server starts cleanly without the enricher running (no new background-task coupling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)