### PR TITLE
feat(reports): add abuse pipeline MCP tools (query + submit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@ Registration), so it works as a remote connector in the Claude mobile app.
 
 ## Tools
 
-| Tool                 | What it does                                        |
-| -------------------- | --------------------------------------------------- |
-| `tmux_list_sessions` | List active tmux sessions on the host               |
-| `tmux_get_summary`   | Capture the last N lines from a tmux pane           |
-| `tmux_send_prompt`   | Send a prompt string to a tmux pane (optional Enter)|
+| Tool                  | What it does                                                  |
+| --------------------- | ------------------------------------------------------------- |
+| `tmux_list_sessions`  | List active tmux sessions on the host                         |
+| `tmux_get_summary`    | Capture the last N lines from a tmux pane                     |
+| `tmux_send_prompt`    | Send a prompt string to a tmux pane (optional Enter)          |
+| `abuse_get_pending`   | List IPs still accumulating 429 responses in `pending/`       |
+| `abuse_get_staged`    | List enriched abuse reports in `staged/` (ready to submit)    |
+| `abuse_list_reported` | List archived submissions in `reported/` (period required)    |
+| `abuse_send_report`   | Submit an abuse report to AbuseIPDB and archive the file      |
+
+The `abuse_*` tools pair with the [optional abuse reporting pipeline](#abuse-reporting-pipeline-optional) below. `abuse_send_report` requires `TMUX_MCP_ABUSEIPDB_KEY`; the others work with just the log directory.
 
 ## Setup
 
@@ -106,15 +112,36 @@ just re-auth, which is quick since GitHub remembers the authorization.
 └── jwt-key.pem    # RSA private key for signing access tokens (mode 600)
 ```
 
-## Abuse-report enricher (optional)
+## Abuse reporting pipeline (optional)
 
-A separate process watches `{TMUX_MCP_LOG_DIR:-./logs}/pending/` for rate-limited-IP logs, enriches each file (ASN + country via RIPE Stat, AbuseIPDB category heuristics), and moves it to `staged/` once the file has been idle for 60 seconds. Run it alongside the server if you want to collect data for abuse reports:
+A three-part pipeline for collecting malicious IP activity and submitting reports to [AbuseIPDB](https://www.abuseipdb.com/):
 
-```sh
-uv run tmux-mcp-enricher
-```
+1. **Collector** — the rate-limit middleware writes every 429 to `{TMUX_MCP_LOG_DIR:-./logs}/pending/{ip}.log` (built into the server, always on).
+2. **Enricher** — a separate process watches `pending/`, debounces (60s quiet window), looks up ASN + country via RIPE Stat, detects AbuseIPDB categories, and moves files to `staged/`. Run alongside the server:
 
-Runs independently of the main server — restart either without affecting the other. RIPE lookup failures are treated as non-fatal; enrichment proceeds with `unknown` fields. Planned Part 3 (upstream `send_report` MCP tool) will consume `staged/` and submit to AbuseIPDB.
+   ```sh
+   uv run tmux-mcp-enricher
+   ```
+
+   Runs independently — restart either without affecting the other. RIPE lookup failures are non-fatal; enrichment proceeds with `unknown` fields.
+3. **MCP tools** — `abuse_get_pending`, `abuse_get_staged`, `abuse_list_reported`, `abuse_send_report`. Use them from the agent to inspect the pipeline and submit reports.
+
+### Getting an AbuseIPDB API key
+
+`abuse_send_report` requires a free AbuseIPDB account:
+
+1. Sign up at [abuseipdb.com/register](https://www.abuseipdb.com/register).
+2. Verify your email.
+3. Go to [abuseipdb.com/account/api](https://www.abuseipdb.com/account/api) and click **Create Key**. The free tier allows up to 1,000 submissions per day — plenty for a single-host deployment.
+4. Add the key to `.env`:
+
+   ```sh
+   TMUX_MCP_ABUSEIPDB_KEY=your-key-here
+   ```
+
+5. Restart the server (`uv run tmux-mcp`) so it picks up the new env var.
+
+Without the key, `abuse_send_report` returns a clear error instead of attempting the call — the collector and enricher run fine without it, so you can start gathering data before deciding whether to submit.
 
 ## Shell integrations
 

--- a/src/tmux_mcp/reports.py
+++ b/src/tmux_mcp/reports.py
@@ -1,0 +1,330 @@
+"""Abuse-pipeline reporting — MCP tool implementations.
+
+Four tools expose the pipeline state and let the agent submit reports:
+
+- ``abuse_get_pending(period?)`` — IPs still accumulating in ``pending/``
+- ``abuse_get_staged(period?)`` — enriched reports ready to send in ``staged/``
+- ``abuse_list_reported(period)`` — submitted archive (period required)
+- ``abuse_send_report(filename)`` — POST to AbuseIPDB, archive to ``reported/``
+
+Each tool returns a plain-text summary suitable for an LLM to read. Missing or
+empty folders render a polite empty-state string — never an error.
+
+The module is a library: tests drive these functions directly against temp
+directories. ``server.py`` registers the thin ``@mcp.tool`` wrappers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import httpx
+
+from tmux_mcp.enricher import promote_file
+
+
+logger = logging.getLogger("tmux_mcp.reports")
+
+ABUSEIPDB_URL = "https://api.abuseipdb.com/api/v2/report"
+ABUSEIPDB_TIMEOUT = 10.0
+
+# Report filename pattern: {ip}-{YYYYMMDDTHHMMSSZ}.log — IPv6 colons already
+# replaced with underscores upstream (see ratelimit.py).
+_REPORTED_FILENAME_RE = re.compile(
+    r"^(?P<ip>[^-]+(?:-[^-]+)*?)-(?P<ts>\d{8}T\d{6}Z)\.log$"
+)
+_REPORTED_TS_FMT = "%Y%m%dT%H%M%SZ"
+
+
+# ── Empty-state strings (exact per issue #13 spec) ─────────────────────────
+
+EMPTY_PENDING = "No scanning attempts available"
+EMPTY_STAGED = "No staged error reports found"
+EMPTY_REPORTED = "No reports filed"
+
+
+# ── Period parser ──────────────────────────────────────────────────────────
+
+
+def parse_period(period: str | None) -> datetime | None:
+    """Parse a period spec into a UTC cutoff datetime.
+
+    Accepts:
+    - ``None`` or ``""`` → no filter (returns ``None``)
+    - ``last_day`` → 24h ago
+    - ``last_week`` → 7d ago
+    - ``since:YYYY-MM-DD`` → midnight UTC of that date
+    """
+    if not period:
+        return None
+    now = datetime.now(timezone.utc)
+    if period == "last_day":
+        return now - timedelta(days=1)
+    if period == "last_week":
+        return now - timedelta(days=7)
+    if period.startswith("since:"):
+        try:
+            d = datetime.strptime(period[6:], "%Y-%m-%d")
+            return d.replace(tzinfo=timezone.utc)
+        except ValueError as e:
+            raise ValueError(
+                f"invalid since: date '{period[6:]}' (expected YYYY-MM-DD)"
+            ) from e
+    raise ValueError(
+        f"unknown period '{period}' (expected last_day, last_week, since:YYYY-MM-DD)"
+    )
+
+
+def _parse_iso_z(ts: str) -> datetime | None:
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+# ── get_pending ─────────────────────────────────────────────────────────────
+
+
+def get_pending(log_root: Path, period: str | None = None) -> str:
+    cutoff = parse_period(period)
+    pending = log_root / "pending"
+    if not pending.is_dir():
+        return EMPTY_PENDING
+
+    rows: list[tuple[str, int, str]] = []
+    for f in sorted(pending.glob("*.log")):
+        try:
+            lines = [ln for ln in f.read_text().splitlines() if ln.strip()]
+        except OSError:
+            continue
+        if not lines:
+            continue
+        last_line = lines[-1]
+        last_ts = last_line.split()[0] if last_line else ""
+        if cutoff is not None:
+            dt = _parse_iso_z(last_ts) or datetime.fromtimestamp(
+                f.stat().st_mtime, timezone.utc
+            )
+            if dt < cutoff:
+                continue
+        ip = f.stem.replace("_", ":") if "_" in f.stem else f.stem
+        rows.append((ip, len(lines), last_ts))
+
+    if not rows:
+        return EMPTY_PENDING
+
+    header = f"{len(rows)} pending IP(s):"
+    body = "\n".join(
+        f"  {ip} — {count} entries, last seen {ts}" for ip, count, ts in rows
+    )
+    return f"{header}\n{body}"
+
+
+# ── get_staged ─────────────────────────────────────────────────────────────
+
+
+def _parse_staged_header(path: Path) -> dict | None:
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    head, _, _ = text.partition("\nRequests:\n")
+    out: dict[str, str] = {}
+    for line in head.splitlines():
+        if ":" in line:
+            k, _, v = line.partition(":")
+            out[k.strip()] = v.strip()
+    return out if out else None
+
+
+def get_staged(log_root: Path, period: str | None = None) -> str:
+    cutoff = parse_period(period)
+    staged = log_root / "staged"
+    if not staged.is_dir():
+        return EMPTY_STAGED
+
+    rows: list[tuple[str, dict]] = []
+    for f in sorted(staged.glob("*.log")):
+        hdr = _parse_staged_header(f)
+        if not hdr:
+            continue
+        last_seen = hdr.get("LastSeen", "")
+        if cutoff is not None:
+            dt = _parse_iso_z(last_seen) or datetime.fromtimestamp(
+                f.stat().st_mtime, timezone.utc
+            )
+            if dt < cutoff:
+                continue
+        rows.append((f.name, hdr))
+
+    if not rows:
+        return EMPTY_STAGED
+
+    header = f"{len(rows)} staged report(s):"
+    lines = [header]
+    for name, hdr in rows:
+        lines.append(
+            f"  {name} — {hdr.get('IP', '?')} | "
+            f"{hdr.get('RIR', 'unknown')} | "
+            f"cats={hdr.get('AbuseIPDB-Categories', 'none')} | "
+            f"{hdr.get('RequestCount', '?')} requests | "
+            f"last={hdr.get('LastSeen', '?')}"
+        )
+    return "\n".join(lines)
+
+
+# ── list_reported ───────────────────────────────────────────────────────────
+
+
+def list_reported(log_root: Path, period: str) -> str:
+    if not period:
+        raise ValueError("period is required for list_reported")
+    cutoff = parse_period(period)
+    reported = log_root / "reported"
+    if not reported.is_dir():
+        return EMPTY_REPORTED
+
+    rows: list[tuple[str, datetime | None]] = []
+    for f in sorted(reported.glob("*.log")):
+        m = _REPORTED_FILENAME_RE.match(f.name)
+        if not m:
+            continue
+        try:
+            dt = datetime.strptime(m.group("ts"), _REPORTED_TS_FMT).replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            dt = None
+        if cutoff is not None and dt is not None and dt < cutoff:
+            continue
+        rows.append((f.name, dt))
+
+    if not rows:
+        return EMPTY_REPORTED
+
+    header = f"{len(rows)} reported submission(s):"
+    body = "\n".join(
+        f"  {name} — submitted {dt.isoformat() if dt else '?'}" for name, dt in rows
+    )
+    return f"{header}\n{body}"
+
+
+# ── send_report ─────────────────────────────────────────────────────────────
+
+
+async def _submit_abuseipdb(
+    client: httpx.AsyncClient,
+    api_key: str,
+    ip: str,
+    categories: list[int],
+    comment: str,
+) -> tuple[bool, str]:
+    """POST a report to AbuseIPDB. Returns (ok, message).
+
+    Non-2xx responses are treated as submission failures; the caller should
+    not archive the file so it stays available for retry. Network errors
+    raise httpx exceptions — caller catches and formats.
+    """
+    try:
+        r = await client.post(
+            ABUSEIPDB_URL,
+            data={
+                "ip": ip,
+                "categories": ",".join(str(c) for c in categories),
+                "comment": comment,
+            },
+            headers={"Key": api_key, "Accept": "application/json"},
+            timeout=ABUSEIPDB_TIMEOUT,
+        )
+    except httpx.HTTPError as e:
+        return False, f"AbuseIPDB request failed: {e}"
+    if r.status_code >= 400:
+        return False, f"AbuseIPDB rejected submission (HTTP {r.status_code}): {r.text}"
+    return True, f"AbuseIPDB accepted submission (HTTP {r.status_code})"
+
+
+def _reported_name(ip: str) -> str:
+    ts = datetime.now(timezone.utc).strftime(_REPORTED_TS_FMT)
+    safe_ip = ip.replace(":", "_")
+    return f"{safe_ip}-{ts}.log"
+
+
+async def send_report(
+    log_root: Path,
+    filename: str,
+    api_key: str | None,
+    client: httpx.AsyncClient | None = None,
+) -> str:
+    if not api_key:
+        return (
+            "Cannot submit: TMUX_MCP_ABUSEIPDB_KEY is not set. "
+            "Configure it and try again."
+        )
+
+    # Reject path traversal — filename must be a bare *.log, no slashes.
+    if "/" in filename or "\\" in filename or not filename.endswith(".log"):
+        return f"Invalid filename '{filename}': expected a bare *.log name."
+
+    staged = log_root / "staged" / filename
+    pending = log_root / "pending" / filename
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient()
+
+    try:
+        source = None
+        if staged.exists():
+            source = staged
+        elif pending.exists():
+            # Inline enrichment before submission.
+            promoted = await promote_file(pending, log_root / "staged", client)
+            if promoted is None:
+                return f"File '{filename}' is empty or malformed."
+            source = promoted
+        else:
+            return (
+                f"File '{filename}' not found in staged/ or pending/. "
+                "Check abuse_get_staged / abuse_get_pending."
+            )
+
+        hdr = _parse_staged_header(source) or {}
+        ip = hdr.get("IP")
+        if not ip:
+            return f"Staged file '{source.name}' has no IP header — cannot submit."
+        cats_str = hdr.get("AbuseIPDB-Categories", "")
+        try:
+            categories = [
+                int(c) for c in cats_str.split(",") if c.strip() and c != "none"
+            ]
+        except ValueError:
+            categories = []
+        if not categories:
+            return (
+                f"Staged file '{source.name}' has no categories — nothing to "
+                "submit. Re-run the enricher or edit the header."
+            )
+
+        comment = (
+            f"Automated report from tmux-mcp abuse pipeline. "
+            f"RequestCount={hdr.get('RequestCount', '?')}, "
+            f"FirstSeen={hdr.get('FirstSeen', '?')}, "
+            f"LastSeen={hdr.get('LastSeen', '?')}."
+        )
+        ok, message = await _submit_abuseipdb(client, api_key, ip, categories, comment)
+        if not ok:
+            return f"{message}\nFile left in place for retry: {source}"
+
+        # Archive — move staged → reported. Only after a successful submit.
+        reported_dir = log_root / "reported"
+        reported_dir.mkdir(parents=True, exist_ok=True)
+        dest = reported_dir / _reported_name(ip)
+        shutil.move(str(source), str(dest))
+        logger.info("reported ip=%s categories=%s -> %s", ip, categories, dest.name)
+        return f"{message}\nArchived to {dest.name}."
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/src/tmux_mcp/server.py
+++ b/src/tmux_mcp/server.py
@@ -36,6 +36,7 @@ from starlette.responses import PlainTextResponse, RedirectResponse
 
 from tmux_mcp.auth import STATE_DIR, GithubOAuthProvider
 from tmux_mcp.ratelimit import RateLimitMiddleware
+from tmux_mcp import reports as _reports
 
 # Load .env from CWD or project root before any env reads.
 load_dotenv()
@@ -382,6 +383,119 @@ async def tmux_list_sessions() -> str:
 
     sessions = [line.strip() for line in stdout.splitlines() if line.strip()]
     return json.dumps({"sessions": sessions}, indent=2)
+
+
+# ── Abuse-pipeline tools ─────────────────────────────────────────────────────
+
+PeriodArg = Annotated[
+    str | None,
+    Field(
+        default=None,
+        description=(
+            "Optional time filter: 'last_day', 'last_week', or 'since:YYYY-MM-DD'. "
+            "Omit for all."
+        ),
+    ),
+]
+
+
+def _log_root() -> "Path":
+    return Path(LOG_DIR).expanduser()
+
+
+@mcp.tool(
+    name="abuse_get_pending",
+    annotations={
+        "title": "List Pending Abuse Logs",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def abuse_get_pending(period: PeriodArg = None) -> str:
+    """List IPs currently accumulating 429 responses in pending/.
+
+    Returns a plain-text summary with entry count and last-seen per IP.
+    """
+    try:
+        return _reports.get_pending(_log_root(), period)
+    except ValueError as e:
+        return f"Invalid period: {e}"
+
+
+@mcp.tool(
+    name="abuse_get_staged",
+    annotations={
+        "title": "List Staged Abuse Reports",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def abuse_get_staged(period: PeriodArg = None) -> str:
+    """List enriched abuse reports in staged/ (ready to submit)."""
+    try:
+        return _reports.get_staged(_log_root(), period)
+    except ValueError as e:
+        return f"Invalid period: {e}"
+
+
+@mcp.tool(
+    name="abuse_list_reported",
+    annotations={
+        "title": "List Submitted Abuse Reports",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+async def abuse_list_reported(
+    period: Annotated[
+        str,
+        Field(
+            description=(
+                "Required time filter: 'last_day', 'last_week', or 'since:YYYY-MM-DD'."
+            ),
+        ),
+    ],
+) -> str:
+    """List archived submissions in reported/ (filter required — archive grows)."""
+    try:
+        return _reports.list_reported(_log_root(), period)
+    except ValueError as e:
+        return f"Invalid period: {e}"
+
+
+@mcp.tool(
+    name="abuse_send_report",
+    annotations={
+        "title": "Submit Abuse Report",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+async def abuse_send_report(
+    filename: Annotated[
+        str,
+        Field(
+            description="Bare filename from staged/ or pending/ (e.g. '1.2.3.4.log')."
+        ),
+    ],
+) -> str:
+    """Submit an abuse report to AbuseIPDB and archive the file.
+
+    Accepts a filename from staged/ or pending/; pending files are enriched
+    inline before submission. On success, moves the file to
+    reported/{ip}-{timestamp}.log. On any failure, leaves the file in place
+    so the submission can be retried.
+    """
+    api_key = os.environ.get("TMUX_MCP_ABUSEIPDB_KEY", "")
+    return await _reports.send_report(_log_root(), filename, api_key or None)
 
 
 # ── Middleware ───────────────────────────────────────────────────────────────

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,340 @@
+"""Tests for abuse-pipeline MCP tool implementations."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tmux_mcp.reports import (
+    EMPTY_PENDING,
+    EMPTY_REPORTED,
+    EMPTY_STAGED,
+    get_pending,
+    get_staged,
+    list_reported,
+    parse_period,
+    send_report,
+)
+
+
+# ── parse_period ────────────────────────────────────────────────────────────
+
+
+def test_parse_period_none_returns_none():
+    assert parse_period(None) is None
+    assert parse_period("") is None
+
+
+def test_parse_period_last_day():
+    now = datetime.now(timezone.utc)
+    cutoff = parse_period("last_day")
+    assert cutoff is not None
+    assert abs((now - cutoff) - timedelta(days=1)) < timedelta(seconds=5)
+
+
+def test_parse_period_last_week():
+    now = datetime.now(timezone.utc)
+    cutoff = parse_period("last_week")
+    assert cutoff is not None
+    assert abs((now - cutoff) - timedelta(days=7)) < timedelta(seconds=5)
+
+
+def test_parse_period_since():
+    cutoff = parse_period("since:2025-01-15")
+    assert cutoff == datetime(2025, 1, 15, tzinfo=timezone.utc)
+
+
+def test_parse_period_invalid_since():
+    with pytest.raises(ValueError):
+        parse_period("since:not-a-date")
+
+
+def test_parse_period_unknown():
+    with pytest.raises(ValueError):
+        parse_period("yesterday")
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def log_root(tmp_path: Path) -> Path:
+    (tmp_path / "pending").mkdir()
+    (tmp_path / "staged").mkdir()
+    (tmp_path / "reported").mkdir()
+    return tmp_path
+
+
+def _write_pending(log_root: Path, ip: str, lines: list[str]) -> Path:
+    f = log_root / "pending" / f"{ip}.log"
+    f.write_text("\n".join(lines) + "\n")
+    return f
+
+
+def _write_staged(log_root: Path, ip: str, header: dict, body: list[str]) -> Path:
+    f = log_root / "staged" / f"{ip}.log"
+    head = "\n".join(f"{k}: {v}" for k, v in header.items())
+    body_text = "\n".join(body)
+    f.write_text(f"{head}\n\nRequests:\n{body_text}\n")
+    return f
+
+
+# ── get_pending ─────────────────────────────────────────────────────────────
+
+
+def test_get_pending_empty_folder(log_root):
+    assert get_pending(log_root) == EMPTY_PENDING
+
+
+def test_get_pending_missing_folder(tmp_path):
+    assert get_pending(tmp_path) == EMPTY_PENDING
+
+
+def test_get_pending_lists_ips_with_counts(log_root):
+    _write_pending(
+        log_root,
+        "1.2.3.4",
+        [
+            "2026-04-23T10:00:00Z 1.2.3.4 GET /a 429",
+            "2026-04-23T10:00:01Z 1.2.3.4 GET /b 429",
+        ],
+    )
+    _write_pending(log_root, "5.6.7.8", ["2026-04-23T11:00:00Z 5.6.7.8 GET /c 429"])
+    out = get_pending(log_root)
+    assert "2 pending IP(s)" in out
+    assert "1.2.3.4 — 2 entries" in out
+    assert "5.6.7.8 — 1 entries" in out
+
+
+def test_get_pending_period_filter_by_last_seen(log_root):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    _write_pending(log_root, "1.1.1.1", [f"{today} 1.1.1.1 GET /new 429"])
+    _write_pending(log_root, "2.2.2.2", [f"{old} 2.2.2.2 GET /old 429"])
+    out = get_pending(log_root, "last_week")
+    assert "1.1.1.1" in out
+    assert "2.2.2.2" not in out
+
+
+# ── get_staged ──────────────────────────────────────────────────────────────
+
+
+def test_get_staged_empty_folder(log_root):
+    assert get_staged(log_root) == EMPTY_STAGED
+
+
+def test_get_staged_missing_folder(tmp_path):
+    assert get_staged(tmp_path) == EMPTY_STAGED
+
+
+def test_get_staged_lists_header_summary(log_root):
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {
+            "IP": "1.2.3.4",
+            "ASN": "AS8758 (Iway AG)",
+            "Country": "CH",
+            "RIR": "RIPE NCC",
+            "ReportTo": "AbuseIPDB, RIPE NCC",
+            "AbuseIPDB-Categories": "19,21",
+            "FirstSeen": "2026-04-23T10:00:00Z",
+            "LastSeen": "2026-04-23T10:05:00Z",
+            "RequestCount": "7",
+        },
+        ["2026-04-23T10:00:00Z GET /wp-login.php 429"],
+    )
+    out = get_staged(log_root)
+    assert "1 staged report(s)" in out
+    assert "1.2.3.4" in out
+    assert "RIPE NCC" in out
+    assert "19,21" in out
+    assert "7 requests" in out
+
+
+def test_get_staged_period_filter(log_root):
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    _write_staged(
+        log_root,
+        "1.1.1.1",
+        {"IP": "1.1.1.1", "LastSeen": today, "AbuseIPDB-Categories": "19"},
+        [f"{today} GET / 429"],
+    )
+    _write_staged(
+        log_root,
+        "2.2.2.2",
+        {"IP": "2.2.2.2", "LastSeen": old, "AbuseIPDB-Categories": "19"},
+        [f"{old} GET / 429"],
+    )
+    out = get_staged(log_root, "last_week")
+    assert "1.1.1.1" in out
+    assert "2.2.2.2" not in out
+
+
+# ── list_reported ───────────────────────────────────────────────────────────
+
+
+def test_list_reported_requires_period(log_root):
+    with pytest.raises(ValueError):
+        list_reported(log_root, "")
+
+
+def test_list_reported_empty_folder(log_root):
+    assert list_reported(log_root, "last_day") == EMPTY_REPORTED
+
+
+def test_list_reported_missing_folder(tmp_path):
+    assert list_reported(tmp_path, "last_day") == EMPTY_REPORTED
+
+
+def test_list_reported_filters_by_filename_timestamp(log_root):
+    now = datetime.now(timezone.utc)
+    old_ts = (now - timedelta(days=30)).strftime("%Y%m%dT%H%M%SZ")
+    new_ts = now.strftime("%Y%m%dT%H%M%SZ")
+    (log_root / "reported" / f"1.1.1.1-{new_ts}.log").write_text("x")
+    (log_root / "reported" / f"2.2.2.2-{old_ts}.log").write_text("x")
+    out = list_reported(log_root, "last_week")
+    assert "1.1.1.1" in out
+    assert "2.2.2.2" not in out
+
+
+def test_list_reported_ignores_bad_filenames(log_root):
+    (log_root / "reported" / "not-a-report.log").write_text("x")
+    out = list_reported(log_root, "last_day")
+    assert out == EMPTY_REPORTED
+
+
+# ── send_report ─────────────────────────────────────────────────────────────
+
+
+def _fake_abuseipdb_ok():
+    resp = AsyncMock()
+    resp.status_code = 200
+    resp.text = '{"data":{"abuseConfidenceScore":100}}'
+    return resp
+
+
+def _fake_abuseipdb_err(status=429):
+    resp = AsyncMock()
+    resp.status_code = status
+    resp.text = '{"errors":[{"detail":"rate limited"}]}'
+    return resp
+
+
+def test_send_report_without_key_returns_error(log_root):
+    result = asyncio.run(send_report(log_root, "1.2.3.4.log", None))
+    assert "TMUX_MCP_ABUSEIPDB_KEY" in result
+
+
+def test_send_report_rejects_path_traversal(log_root):
+    result = asyncio.run(send_report(log_root, "../../../etc/passwd", "key"))
+    assert "Invalid filename" in result
+
+
+def test_send_report_file_not_found(log_root):
+    client = AsyncMock()
+    result = asyncio.run(send_report(log_root, "missing.log", "key", client=client))
+    assert "not found" in result
+
+
+def test_send_report_staged_submits_and_archives(log_root):
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {
+            "IP": "1.2.3.4",
+            "RIR": "RIPE NCC",
+            "AbuseIPDB-Categories": "19,21",
+            "FirstSeen": "2026-04-23T10:00:00Z",
+            "LastSeen": "2026-04-23T10:05:00Z",
+            "RequestCount": "3",
+        },
+        ["2026-04-23T10:00:00Z GET /wp-login.php 429"],
+    )
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=_fake_abuseipdb_ok())
+    result = asyncio.run(
+        send_report(log_root, "1.2.3.4.log", "test-key", client=client)
+    )
+    assert "AbuseIPDB accepted" in result
+    assert "Archived" in result
+    assert not (log_root / "staged" / "1.2.3.4.log").exists()
+    assert any((log_root / "reported").glob("1.2.3.4-*.log"))
+    # Verify POST was called with correct shape.
+    _, kwargs = client.post.call_args
+    assert kwargs["data"]["ip"] == "1.2.3.4"
+    assert kwargs["data"]["categories"] == "19,21"
+    assert kwargs["headers"]["Key"] == "test-key"
+
+
+def test_send_report_leaves_file_on_abuseipdb_error(log_root):
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {"IP": "1.2.3.4", "AbuseIPDB-Categories": "19"},
+        ["2026-04-23T10:00:00Z GET /wp-login.php 429"],
+    )
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=_fake_abuseipdb_err(429))
+    result = asyncio.run(
+        send_report(log_root, "1.2.3.4.log", "test-key", client=client)
+    )
+    assert "rejected" in result
+    assert "retry" in result
+    # File still in staged/; nothing in reported/.
+    assert (log_root / "staged" / "1.2.3.4.log").exists()
+    assert not any((log_root / "reported").glob("*.log"))
+
+
+def test_send_report_on_pending_runs_enrichment_inline(log_root):
+    _write_pending(
+        log_root,
+        "1.2.3.4",
+        [
+            "2026-04-23T10:00:00Z 1.2.3.4 GET /wp-login.php 429",
+            "2026-04-23T10:00:01Z 1.2.3.4 GET /.env 429",
+            "2026-04-23T10:00:02Z 1.2.3.4 GET /phpmyadmin 429",
+        ],
+    )
+    client = AsyncMock()
+
+    # Simulate RIPE offline (irrelevant for category detection).
+    async def _get(url, **_):
+        raise Exception("ripe offline")
+
+    client.get = AsyncMock(side_effect=_get)
+    client.post = AsyncMock(return_value=_fake_abuseipdb_ok())
+
+    result = asyncio.run(
+        send_report(log_root, "1.2.3.4.log", "test-key", client=client)
+    )
+    assert "accepted" in result
+    assert "Archived" in result
+    # Pending file gone (promoted then archived).
+    assert not (log_root / "pending" / "1.2.3.4.log").exists()
+    # Reported archive has it.
+    assert any((log_root / "reported").glob("1.2.3.4-*.log"))
+
+
+def test_send_report_no_categories_refuses(log_root):
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {"IP": "1.2.3.4", "AbuseIPDB-Categories": "none"},
+        ["2026-04-23T10:00:00Z GET / 429"],
+    )
+    client = AsyncMock()
+    client.post = AsyncMock()
+    result = asyncio.run(send_report(log_root, "1.2.3.4.log", "key", client=client))
+    assert "no categories" in result
+    client.post.assert_not_called()
+    assert (log_root / "staged" / "1.2.3.4.log").exists()


### PR DESCRIPTION
Closes #13 · Part of #14

## Summary

- New `tmux_mcp.reports` library + four MCP tools: `abuse_get_pending`, `abuse_get_staged`, `abuse_list_reported`, `abuse_send_report`
- Period filter: `last_day` / `last_week` / `since:YYYY-MM-DD` / None (optional for pending + staged, required for reported — archive grows)
- Per-folder filter source: mtime + last-line timestamp (pending), `LastSeen` header (staged), filename timestamp (reported)
- `send_report` safety: missing key → actionable error; path traversal rejected; pending files enriched inline; non-2xx → file stays for retry; success → move to `reported/{ip}-{YYYYMMDDTHHMMSSZ}.log`
- Empty-state strings match spec exactly: "No scanning attempts available" / "No staged error reports found" / "No reports filed"
- 26 new tests; 109 total green

## Test plan

- [x] Deploy with no \`TMUX_MCP_LOG_DIR\`/logs → \`abuse_get_pending\` returns "No scanning attempts available"
- [x] Accumulate some pending files, run the enricher → \`abuse_get_staged\` lists them with RIR + categories
- [x] \`abuse_send_report\` without \`TMUX_MCP_ABUSEIPDB_KEY\` → clean error, nothing submitted
- [x] Set a valid AbuseIPDB key and submit a staged report → verify entry appears in \`reported/\` and the original staged file is gone
- [x] Submit again with a bad/rate-limited key → file stays in place, error surfaced
- [x] \`abuse_list_reported period=last_week\` → shows only recent archive entries, ignores any malformed filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)