### PR TITLE
feat(ratelimit): skip ban for benign 404 paths

### DIFF
--- a/src/tmux_mcp/ratelimit.py
+++ b/src/tmux_mcp/ratelimit.py
@@ -34,6 +34,21 @@ from typing import Iterable
 logger = logging.getLogger("tmux_mcp.ratelimit")
 
 
+# Paths that normal browsers and well-behaved crawlers request unprompted.
+# A 404 here is noise, not a scanner signal — don't escalate to a ban.
+_BENIGN_404_PATHS: frozenset[str] = frozenset(
+    {
+        "/",
+        "/favicon.ico",
+        "/robots.txt",
+        "/sitemap.xml",
+        "/rss.xml",
+        "/atom.xml",
+        "/feed.xml",
+    }
+)
+
+
 def _load_ip_file(path: Path) -> set[str]:
     if not path.exists():
         return set()
@@ -147,6 +162,8 @@ class RateLimitMiddleware:
             return
 
         if status == 404:
+            if scope.get("path") in _BENIGN_404_PATHS:
+                return
             self._ban(ip, reason="404")
             return
 


### PR DESCRIPTION
Closes #18

## Summary
- Add `_BENIGN_404_PATHS` greylist in `src/tmux_mcp/ratelimit.py`: `/`, `/favicon.ico`, `/robots.txt`, `/sitemap.xml`, `/rss.xml`, `/atom.xml`, `/feed.xml`.
- A 404 on a greylisted path returns without mutating state — no ban, no whitelist, no pending-log entry.
- 401/403 sliding-window rule and other 404 handling unchanged.

## Test plan
- [x] Hit the public URL in a browser → `/favicon.ico` 404 does not ban
- [x] Unknown probe path (e.g. `/.env`) still triggers an immediate ban
- [x] Auth-failure sliding window still bans after >10 in 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)