### PR TITLE
feat(enricher): route uncategorized reports to saved/ and accumulate per-IP

### DIFF
--- a/src/tmux_mcp/enricher.py
+++ b/src/tmux_mcp/enricher.py
@@ -1,4 +1,4 @@
-"""Abuse pipeline — watches ``pending/``, debounces, enriches, moves to ``staged/``.
+"""Abuse pipeline — watches ``pending/``, debounces, enriches, files to ``staged/`` or ``saved/``.
 
 When a per-IP file under ``pending/`` has been quiet for ``quiet_seconds``
 (default 60s), enrich it with:
@@ -9,8 +9,14 @@ When a per-IP file under ``pending/`` has been quiet for ``quiet_seconds``
 - **AbuseIPDB categories** (heuristic on request paths)
 - **FirstSeen / LastSeen / RequestCount**
 
-and move it to ``staged/``. If any RIPE lookup fails, the corresponding field
-is left as ``unknown`` — enrichment never blocks the pipeline.
+If categorization produces at least one AbuseIPDB category, the file is
+filed under ``staged/`` (submittable). Otherwise it goes to ``saved/`` —
+evidence we don't want to lose but can't yet report. On subsequent runs,
+new requests for the same IP merge into the existing ``saved/`` file; if
+the merged set later qualifies, it is promoted to ``staged/``.
+
+If any RIPE lookup fails, the corresponding field is left as ``unknown`` —
+enrichment never blocks the pipeline.
 
 The watcher is a pure poll loop (5s tick). No ``watchdog`` dependency, no
 inotify — keeps the code portable and testable.
@@ -103,6 +109,11 @@ _COUNTRY_TO_RIR: dict[str, str] = {
 
 _LINE_RE = re.compile(
     r"^(?P<ts>\S+)\s+(?P<ip>\S+)\s+(?P<method>\S+)\s+(?P<path>\S+)\s+(?P<status>\d+)$"
+)
+
+# Body lines in staged/saved files omit the IP (it's in the header).
+_BODY_LINE_RE = re.compile(
+    r"^(?P<ts>\S+)\s+(?P<method>\S+)\s+(?P<path>\S+)\s+(?P<status>\d+)$"
 )
 
 
@@ -199,18 +210,81 @@ async def _ripe_lookup(client: httpx.AsyncClient, ip: str) -> dict:
     return out
 
 
+# ── Saved-file parsing (for cross-run accumulation) ─────────────────────────
+
+
+def _load_saved_file(path: Path) -> tuple[dict, list[dict]] | None:
+    """Parse an existing saved/staged file. Returns (header_fields, requests)
+    or ``None`` if the file is missing or malformed.
+    """
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text()
+    except OSError as e:
+        logger.warning("cannot read saved file %s: %s", path, e)
+        return None
+    if "\nRequests:\n" not in text:
+        return None
+    header_text, body_text = text.split("\nRequests:\n", 1)
+    fields: dict[str, str] = {}
+    for ln in header_text.splitlines():
+        if ":" in ln:
+            k, v = ln.split(":", 1)
+            fields[k.strip()] = v.strip()
+    requests: list[dict] = []
+    for ln in body_text.splitlines():
+        m = _BODY_LINE_RE.match(ln.strip())
+        if m:
+            requests.append(m.groupdict())
+    return fields, requests
+
+
+def _format_report_text(
+    ip: str,
+    asn_field: str,
+    country: str,
+    rir: str,
+    cats: list[int],
+    requests: list[dict],
+) -> str:
+    header = (
+        f"IP: {ip}\n"
+        f"ASN: {asn_field}\n"
+        f"Country: {country}\n"
+        f"RIR: {rir}\n"
+        f"ReportTo: {report_to(rir)}\n"
+        f"AbuseIPDB-Categories: {','.join(str(c) for c in cats) or 'none'}\n"
+        f"FirstSeen: {requests[0]['ts']}\n"
+        f"LastSeen: {requests[-1]['ts']}\n"
+        f"RequestCount: {len(requests)}\n"
+        f"\n"
+        f"Requests:\n"
+    )
+    body = "\n".join(
+        f"{r['ts']} {r['method']} {r['path']} {r['status']}" for r in requests
+    )
+    return header + body + "\n"
+
+
 # ── Promote one pending file ────────────────────────────────────────────────
 
 
 async def promote_file(
     pending_path: Path,
     staged_dir: Path,
+    saved_dir: Path,
     client: httpx.AsyncClient,
 ) -> Path | None:
-    """Read a pending file, enrich it, write the staged file, delete pending.
+    """Read a pending file, enrich it, file it under ``staged/`` (categorized)
+    or ``saved/`` (uncategorized), and delete the pending file.
 
-    Returns the staged path on success, ``None`` if the file is empty or
-    malformed.
+    Uncategorized requests merge into any existing ``saved/{ip}.log``. If the
+    merged set later qualifies, the file is promoted to ``staged/`` and the
+    saved entry is removed.
+
+    Returns the destination path on success, ``None`` if the pending file is
+    empty or malformed.
     """
     try:
         lines = [ln for ln in pending_path.read_text().splitlines() if ln.strip()]
@@ -218,7 +292,7 @@ async def promote_file(
         logger.warning("cannot read pending file %s: %s", pending_path, e)
         return None
 
-    requests: list[dict] = []
+    new_requests: list[dict] = []
     ip: str | None = None
     for ln in lines:
         parsed = parse_log_line(ln)
@@ -226,9 +300,9 @@ async def promote_file(
             continue
         if ip is None:
             ip = parsed["ip"]
-        requests.append(parsed)
+        new_requests.append(parsed)
 
-    if not requests or ip is None:
+    if not new_requests or ip is None:
         logger.info("skipping empty or malformed pending file: %s", pending_path)
         pending_path.unlink(missing_ok=True)
         return None
@@ -238,39 +312,57 @@ async def promote_file(
     holder = ripe.get("asn_holder")
     asn_field = f"{asn} ({holder})" if holder else asn
     country = ripe.get("country", "unknown")
-    rir = rir_for_country(ripe.get("country"))
-    cats = detect_categories(requests)
-    first_seen = requests[0]["ts"]
-    last_seen = requests[-1]["ts"]
 
-    staged_dir.mkdir(parents=True, exist_ok=True)
-    staged_path = staged_dir / pending_path.name
-    header = (
-        f"IP: {ip}\n"
-        f"ASN: {asn_field}\n"
-        f"Country: {country}\n"
-        f"RIR: {rir}\n"
-        f"ReportTo: {report_to(rir)}\n"
-        f"AbuseIPDB-Categories: {','.join(str(c) for c in cats) or 'none'}\n"
-        f"FirstSeen: {first_seen}\n"
-        f"LastSeen: {last_seen}\n"
-        f"RequestCount: {len(requests)}\n"
-        f"\n"
-        f"Requests:\n"
+    # Merge with any existing saved file for this IP. Preserve previously
+    # resolved RIPE fields if the current lookup came back as "unknown" —
+    # avoids regressing good metadata when RIPE is flaky.
+    saved_path = saved_dir / pending_path.name
+    existing = _load_saved_file(saved_path)
+    if existing:
+        existing_fields, existing_requests = existing
+        if asn == "unknown" and existing_fields.get("ASN", "unknown") != "unknown":
+            asn_field = existing_fields["ASN"]
+        if (
+            country == "unknown"
+            and existing_fields.get("Country", "unknown") != "unknown"
+        ):
+            country = existing_fields["Country"]
+        all_requests = existing_requests + new_requests
+    else:
+        all_requests = new_requests
+
+    rir = rir_for_country(country if country != "unknown" else None)
+    cats = detect_categories(all_requests)
+
+    if cats:
+        target_dir = staged_dir
+        bucket = "staged"
+    else:
+        target_dir = saved_dir
+        bucket = "saved"
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / pending_path.name
+    target_path.write_text(
+        _format_report_text(ip, asn_field, country, rir, cats, all_requests)
     )
-    body = "\n".join(
-        f"{r['ts']} {r['method']} {r['path']} {r['status']}" for r in requests
-    )
-    staged_path.write_text(header + body + "\n")
+
+    # Remove a stale saved entry if the merged file is now categorized and
+    # has been promoted out of saved/.
+    if existing and bucket == "staged":
+        saved_path.unlink(missing_ok=True)
+
     pending_path.unlink(missing_ok=True)
     logger.info(
-        "staged %s ip=%s requests=%d categories=%s",
-        staged_path.name,
+        "%s %s ip=%s requests=%d categories=%s%s",
+        bucket,
+        target_path.name,
         ip,
-        len(requests),
+        len(all_requests),
         cats,
+        " (merged from saved/)" if existing else "",
     )
-    return staged_path
+    return target_path
 
 
 # ── Watcher loop ────────────────────────────────────────────────────────────
@@ -279,6 +371,7 @@ async def promote_file(
 async def run_watcher(
     pending_dir: Path,
     staged_dir: Path,
+    saved_dir: Path,
     *,
     quiet_seconds: float = 60.0,
     tick_seconds: float = 5.0,
@@ -292,16 +385,17 @@ async def run_watcher(
     if owns_client:
         client = httpx.AsyncClient()
     logger.info(
-        "enricher watcher started pending=%s staged=%s quiet=%.0fs tick=%.0fs",
+        "enricher watcher started pending=%s staged=%s saved=%s quiet=%.0fs tick=%.0fs",
         pending_dir,
         staged_dir,
+        saved_dir,
         quiet_seconds,
         tick_seconds,
     )
     try:
         while True:
             try:
-                await _tick(pending_dir, staged_dir, quiet_seconds, client)
+                await _tick(pending_dir, staged_dir, saved_dir, quiet_seconds, client)
             except Exception as e:  # defensive — never let the loop die
                 logger.warning("enricher tick failed: %s", e)
             await asyncio.sleep(tick_seconds)
@@ -328,9 +422,10 @@ def main() -> None:
     log_root = Path(os.environ.get("TMUX_MCP_LOG_DIR", "./logs")).expanduser()
     pending = log_root / "pending"
     staged = log_root / "staged"
-    print(f"tmux-mcp-enricher: watching {pending} → {staged}")
+    saved = log_root / "saved"
+    print(f"tmux-mcp-enricher: watching {pending} → {staged} (saved: {saved})")
     try:
-        asyncio.run(run_watcher(pending, staged))
+        asyncio.run(run_watcher(pending, staged, saved))
     except KeyboardInterrupt:
         print("\nShutting down.")
 
@@ -342,6 +437,7 @@ if __name__ == "__main__":
 async def _tick(
     pending_dir: Path,
     staged_dir: Path,
+    saved_dir: Path,
     quiet_seconds: float,
     client: httpx.AsyncClient,
 ) -> None:
@@ -357,4 +453,4 @@ async def _tick(
             continue
         if now - mtime < quiet_seconds:
             continue
-        await promote_file(entry, staged_dir, client)
+        await promote_file(entry, staged_dir, saved_dir, client)

--- a/src/tmux_mcp/reports.py
+++ b/src/tmux_mcp/reports.py
@@ -281,9 +281,16 @@ async def send_report(
             source = staged
         elif pending.exists():
             # Inline enrichment before submission.
-            promoted = await promote_file(pending, log_root / "staged", client)
+            promoted = await promote_file(
+                pending, log_root / "staged", log_root / "saved", client
+            )
             if promoted is None:
                 return f"File '{filename}' is empty or malformed."
+            if promoted.parent.name != "staged":
+                return (
+                    f"File '{filename}' enriched to {promoted.parent.name}/ — "
+                    "no AbuseIPDB categories detected, cannot submit."
+                )
             source = promoted
         else:
             return (

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -132,11 +132,12 @@ def test_categories_can_combine():
 
 
 @pytest.fixture
-def pending_and_staged(tmp_path: Path) -> tuple[Path, Path]:
+def pending_and_staged(tmp_path: Path) -> tuple[Path, Path, Path]:
     pending = tmp_path / "pending"
     staged = tmp_path / "staged"
+    saved = tmp_path / "saved"
     pending.mkdir()
-    return pending, staged
+    return pending, staged, saved
 
 
 def _write_pending(pending: Path, ip: str, lines: list[str]) -> Path:
@@ -146,7 +147,7 @@ def _write_pending(pending: Path, ip: str, lines: list[str]) -> Path:
 
 
 def test_promote_file_writes_staged_and_removes_pending(pending_and_staged):
-    pending, staged = pending_and_staged
+    pending, staged, saved = pending_and_staged
     file = _write_pending(
         pending,
         "155.2.225.177",
@@ -159,7 +160,7 @@ def test_promote_file_writes_staged_and_removes_pending(pending_and_staged):
 
     client = AsyncMock()
     client.get = AsyncMock(side_effect=Exception("ripe offline"))
-    result = asyncio.run(promote_file(file, staged, client))
+    result = asyncio.run(promote_file(file, staged, saved, client))
 
     assert result is not None
     assert not file.exists()
@@ -178,7 +179,7 @@ def test_promote_file_writes_staged_and_removes_pending(pending_and_staged):
 
 
 def test_promote_file_with_ripe_lookup_populates_asn_country(pending_and_staged):
-    pending, staged = pending_and_staged
+    pending, staged, saved = pending_and_staged
     file = _write_pending(
         pending,
         "155.2.225.177",
@@ -200,7 +201,7 @@ def test_promote_file_with_ripe_lookup_populates_asn_country(pending_and_staged)
     client = AsyncMock()
     client.get = AsyncMock(side_effect=fake_get)
 
-    result = asyncio.run(promote_file(file, staged, client))
+    result = asyncio.run(promote_file(file, staged, saved, client))
     content = result.read_text()
     assert "ASN: AS8758 (Iway AG)" in content
     assert "Country: CH" in content
@@ -209,23 +210,128 @@ def test_promote_file_with_ripe_lookup_populates_asn_country(pending_and_staged)
 
 
 def test_promote_file_empty_is_skipped(pending_and_staged):
-    pending, staged = pending_and_staged
+    pending, staged, saved = pending_and_staged
     file = pending / "1.2.3.4.log"
     file.write_text("\n\n\n")  # no valid lines
     client = AsyncMock()
     client.get = AsyncMock()
-    result = asyncio.run(promote_file(file, staged, client))
+    result = asyncio.run(promote_file(file, staged, saved, client))
     assert result is None
     assert not file.exists()
+
+
+def test_promote_file_uncategorized_routes_to_saved(pending_and_staged):
+    pending, staged, saved = pending_and_staged
+    file = _write_pending(
+        pending, "1.2.3.4", ["2026-04-25T12:00:00Z 1.2.3.4 GET / 429"]
+    )
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=Exception("offline"))
+    result = asyncio.run(promote_file(file, staged, saved, client))
+
+    assert result is not None
+    assert result.parent == saved
+    assert not file.exists()
+    assert not staged.exists() or not any(staged.iterdir())
+    content = result.read_text()
+    assert "AbuseIPDB-Categories: none" in content
+    assert "RequestCount: 1" in content
+
+
+def test_promote_file_merges_into_existing_saved(pending_and_staged):
+    pending, staged, saved = pending_and_staged
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=Exception("offline"))
+
+    # First uncategorized hit lands in saved/.
+    file1 = _write_pending(
+        pending, "1.2.3.4", ["2026-04-25T12:00:00Z 1.2.3.4 GET / 429"]
+    )
+    asyncio.run(promote_file(file1, staged, saved, client))
+
+    # Second uncategorized hit merges in.
+    file2 = _write_pending(
+        pending, "1.2.3.4", ["2026-04-25T12:01:00Z 1.2.3.4 GET / 429"]
+    )
+    result = asyncio.run(promote_file(file2, staged, saved, client))
+
+    assert result.parent == saved
+    content = result.read_text()
+    assert "RequestCount: 2" in content
+    assert "FirstSeen: 2026-04-25T12:00:00Z" in content
+    assert "LastSeen: 2026-04-25T12:01:00Z" in content
+    assert content.count("GET / 429") == 2
+
+
+def test_promote_file_promotes_saved_when_merged_set_qualifies(pending_and_staged):
+    pending, staged, saved = pending_and_staged
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=Exception("offline"))
+
+    # Two uncategorized hits → saved/.
+    f = _write_pending(pending, "1.2.3.4", ["2026-04-25T12:00:00Z 1.2.3.4 GET / 429"])
+    asyncio.run(promote_file(f, staged, saved, client))
+    f = _write_pending(pending, "1.2.3.4", ["2026-04-25T12:01:00Z 1.2.3.4 GET / 429"])
+    asyncio.run(promote_file(f, staged, saved, client))
+
+    # Web-attack probe → should promote merged set to staged/.
+    f = _write_pending(
+        pending, "1.2.3.4", ["2026-04-25T12:02:00Z 1.2.3.4 GET /.env 404"]
+    )
+    result = asyncio.run(promote_file(f, staged, saved, client))
+
+    assert result.parent == staged
+    assert not (saved / "1.2.3.4.log").exists()
+    content = result.read_text()
+    assert "RequestCount: 3" in content
+    assert "AbuseIPDB-Categories: 19" in content
+
+
+def test_promote_file_preserves_existing_ripe_when_lookup_fails(pending_and_staged):
+    pending, staged, saved = pending_and_staged
+    saved.mkdir()
+
+    # Pre-existing saved file with good ASN/Country.
+    (saved / "1.2.3.4.log").write_text(
+        "IP: 1.2.3.4\n"
+        "ASN: AS64500 (TestNet)\n"
+        "Country: DE\n"
+        "RIR: RIPE NCC\n"
+        "ReportTo: AbuseIPDB, RIPE NCC\n"
+        "AbuseIPDB-Categories: none\n"
+        "FirstSeen: 2026-04-25T12:00:00Z\n"
+        "LastSeen: 2026-04-25T12:00:00Z\n"
+        "RequestCount: 1\n"
+        "\n"
+        "Requests:\n"
+        "2026-04-25T12:00:00Z GET / 429\n"
+    )
+
+    file = _write_pending(
+        pending, "1.2.3.4", ["2026-04-25T12:01:00Z 1.2.3.4 GET / 429"]
+    )
+
+    # RIPE returns nothing this time.
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=Exception("offline"))
+    result = asyncio.run(promote_file(file, staged, saved, client))
+
+    content = result.read_text()
+    assert "ASN: AS64500 (TestNet)" in content
+    assert "Country: DE" in content
+    assert "RIR: RIPE NCC" in content
 
 
 # ── Watcher loop ────────────────────────────────────────────────────────────
 
 
 def test_watcher_promotes_quiet_file(pending_and_staged):
-    pending, staged = pending_and_staged
+    pending, staged, saved = pending_and_staged
     file = _write_pending(
-        pending, "9.9.9.9", ["2026-04-23T14:07:37Z 9.9.9.9 GET /a 429"]
+        pending,
+        "9.9.9.9",
+        ["2026-04-23T14:07:37Z 9.9.9.9 GET /wp-login.php 429"],
     )
     # Force mtime to be old enough.
     old = file.stat().st_mtime - 3600
@@ -239,6 +345,7 @@ def test_watcher_promotes_quiet_file(pending_and_staged):
             run_watcher(
                 pending,
                 staged,
+                saved,
                 quiet_seconds=60.0,
                 tick_seconds=0.01,
                 client=client,
@@ -257,7 +364,7 @@ def test_watcher_promotes_quiet_file(pending_and_staged):
 
 
 def test_watcher_leaves_recent_file_alone(pending_and_staged):
-    pending, staged = pending_and_staged
+    pending, staged, saved = pending_and_staged
     file = _write_pending(
         pending, "9.9.9.9", ["2026-04-23T14:07:37Z 9.9.9.9 GET /a 429"]
     )
@@ -271,6 +378,7 @@ def test_watcher_leaves_recent_file_alone(pending_and_staged):
             run_watcher(
                 pending,
                 staged,
+                saved,
                 quiet_seconds=60.0,
                 tick_seconds=0.01,
                 client=client,
@@ -286,6 +394,7 @@ def test_watcher_leaves_recent_file_alone(pending_and_staged):
     asyncio.run(run_briefly())
     assert file.exists()
     assert not staged.exists() or not any(staged.iterdir())
+    assert not saved.exists() or not any(saved.iterdir())
 
 
 def test_watcher_handles_missing_pending_dir(tmp_path):
@@ -297,6 +406,7 @@ def test_watcher_handles_missing_pending_dir(tmp_path):
             run_watcher(
                 tmp_path / "pending-does-not-exist",
                 tmp_path / "staged",
+                tmp_path / "saved",
                 quiet_seconds=60.0,
                 tick_seconds=0.01,
                 client=client,


### PR DESCRIPTION
Closes #20

## Summary
- New `logs/saved/` bucket for evidence with no AbuseIPDB categories.
- `promote_file` merges new pending requests into any existing `saved/{ip}.log`, recomputes categories, and promotes to `staged/` if the merged set now qualifies (then deletes the saved entry).
- Preserves previously resolved ASN/Country when a fresh RIPE lookup comes back as `unknown`.
- `abuse_send_report` on a pending file returns a clear error if enrichment routes it to `saved/`.

## Test plan
- [x] First uncategorized request lands in `logs/saved/{ip}.log`
- [x] Second hit for same IP merges (RequestCount increments, no duplicate file)
- [x] When merged set hits a web-attack pattern, file moves to `staged/` and saved is removed
- [x] Reporting a categorized staged file via `abuse_send_report` still works
- [x] RIPE flake doesn't overwrite previously resolved ASN/Country

🤖 Generated with [Claude Code](https://claude.com/claude-code)