### PR TITLE
feat(reports): add tmux-mcp-report CLI for submitting staged reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Install deps: `uv sync`
 - Run server: `uv run tmux-mcp`
 - Run enricher: `uv run tmux-mcp-enricher`
+- Submit a staged report: `uv run tmux-mcp-report <filename.log>` (also `--list`, `--all`)
 - Lint / format: `uv run ruff check` / `uv run ruff format`
 - Run tests: `uv run pytest`
 - Health check: `curl http://localhost:8747/healthz`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [project.scripts]
 tmux-mcp = "tmux_mcp:main"
 tmux-mcp-enricher = "tmux_mcp.enricher:main"
+tmux-mcp-report = "tmux_mcp.reports:cli_main"
 
 [dependency-groups]
 dev = [

--- a/src/tmux_mcp/reports.py
+++ b/src/tmux_mcp/reports.py
@@ -1,4 +1,4 @@
-"""Abuse-pipeline reporting — MCP tool implementations.
+"""Abuse-pipeline reporting — MCP tool implementations and CLI.
 
 Four tools expose the pipeline state and let the agent submit reports:
 
@@ -12,17 +12,26 @@ empty folders render a polite empty-state string — never an error.
 
 The module is a library: tests drive these functions directly against temp
 directories. ``server.py`` registers the thin ``@mcp.tool`` wrappers.
+
+The ``cli_main`` entry point exposes the same submission surface as a shell
+command (``tmux-mcp-report``) for operators who want to fire reports without
+going through the MCP server.
 """
 
 from __future__ import annotations
 
+import argparse
+import asyncio
 import logging
+import os
 import re
 import shutil
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import httpx
+from dotenv import load_dotenv
 
 from tmux_mcp.enricher import promote_file
 
@@ -335,3 +344,91 @@ async def send_report(
     finally:
         if owns_client:
             await client.aclose()
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def _list_staged(log_root: Path) -> str:
+    staged = log_root / "staged"
+    if not staged.is_dir():
+        return EMPTY_STAGED
+    files = sorted(
+        f.name for f in staged.iterdir() if f.is_file() and f.suffix == ".log"
+    )
+    if not files:
+        return EMPTY_STAGED
+    return "\n".join(files)
+
+
+async def _send_many(log_root: Path, filenames: list[str], api_key: str | None) -> int:
+    """Submit each filename in turn. Returns 0 if all succeeded, 1 otherwise."""
+    failures = 0
+    async with httpx.AsyncClient() as client:
+        for fn in filenames:
+            print(f"=== {fn} ===")
+            result = await send_report(log_root, fn, api_key, client=client)
+            print(result)
+            print()
+            # send_report returns a string; submission failure paths all
+            # contain "Cannot", "Invalid", "not found", "rejected", or
+            # "request failed" — anything that isn't a successful HTTP 200
+            # archive. The successful path always says "Archived to".
+            if "Archived to" not in result:
+                failures += 1
+    return 0 if failures == 0 else 1
+
+
+def cli_main() -> int:
+    """Console-script entry point for ``tmux-mcp-report``."""
+    parser = argparse.ArgumentParser(
+        prog="tmux-mcp-report",
+        description="Submit staged abuse reports to AbuseIPDB.",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "filename",
+        nargs="?",
+        help="Bare *.log filename in logs/staged/ (e.g. 1.2.3.4.log).",
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Submit every staged file in turn.",
+    )
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="List staged filenames and exit.",
+    )
+    args = parser.parse_args()
+
+    load_dotenv()
+    log_root = Path(os.environ.get("TMUX_MCP_LOG_DIR", "./logs")).expanduser()
+    api_key = os.environ.get("TMUX_MCP_ABUSEIPDB_KEY")
+
+    if args.list:
+        print(_list_staged(log_root))
+        return 0
+
+    if args.all:
+        staged = log_root / "staged"
+        if not staged.is_dir():
+            print(EMPTY_STAGED)
+            return 0
+        files = sorted(
+            f.name for f in staged.iterdir() if f.is_file() and f.suffix == ".log"
+        )
+        if not files:
+            print(EMPTY_STAGED)
+            return 0
+        return asyncio.run(_send_many(log_root, files, api_key))
+
+    if not args.filename:
+        parser.error("provide a filename, --all, or --list")
+
+    return asyncio.run(_send_many(log_root, [args.filename], api_key))
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -338,3 +338,87 @@ def test_send_report_no_categories_refuses(log_root):
     assert "no categories" in result
     client.post.assert_not_called()
     assert (log_root / "staged" / "1.2.3.4.log").exists()
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def test_cli_list_empty(log_root, monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(log_root))
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--list"])
+
+    rc = cli_main()
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == EMPTY_STAGED
+
+
+def test_cli_list_returns_filenames(log_root, monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {"IP": "1.2.3.4", "AbuseIPDB-Categories": "19"},
+        ["2026-04-23T10:00:00Z GET /.env 429"],
+    )
+    _write_staged(
+        log_root,
+        "5.6.7.8",
+        {"IP": "5.6.7.8", "AbuseIPDB-Categories": "21"},
+        ["2026-04-23T10:00:00Z GET /a 429"],
+    )
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(log_root))
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--list"])
+
+    rc = cli_main()
+    assert rc == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert sorted(out) == ["1.2.3.4.log", "5.6.7.8.log"]
+
+
+def test_cli_submit_filename_succeeds(log_root, monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {"IP": "1.2.3.4", "AbuseIPDB-Categories": "19"},
+        ["2026-04-23T10:00:00Z GET /.env 429"],
+    )
+
+    async def fake_send_report(log_root_arg, filename, api_key, client=None):
+        return f"AbuseIPDB accepted submission (HTTP 200)\nArchived to {filename}."
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(log_root))
+    monkeypatch.setenv("TMUX_MCP_ABUSEIPDB_KEY", "test-key")
+    monkeypatch.setattr("tmux_mcp.reports.send_report", fake_send_report)
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "1.2.3.4.log"])
+
+    rc = cli_main()
+    assert rc == 0
+    assert "Archived to" in capsys.readouterr().out
+
+
+def test_cli_submit_failure_returns_nonzero(log_root, monkeypatch):
+    from tmux_mcp.reports import cli_main
+
+    async def fake_send_report(log_root_arg, filename, api_key, client=None):
+        return "AbuseIPDB rejected submission (HTTP 422): bad categories"
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(log_root))
+    monkeypatch.setattr("tmux_mcp.reports.send_report", fake_send_report)
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "1.2.3.4.log"])
+
+    assert cli_main() == 1
+
+
+def test_cli_no_args_errors(log_root, monkeypatch):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(log_root))
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report"])
+    with pytest.raises(SystemExit):
+        cli_main()


### PR DESCRIPTION
Closes #24

## Summary
- New `tmux-mcp-report` console script with three modes: `<filename>`, `--all` (submit every staged file), `--list` (print staged filenames).
- Reuses `send_report` — the CLI is just argparse + `load_dotenv` + dispatch. No duplicate submission logic.
- Documented under Commands in CLAUDE.md.
- 5 new tests covering `--list` (empty + populated), single submit, failure exit code, and missing-arg error.

## Test plan
- [x] `uv run tmux-mcp-report --list` shows staged filenames
- [x] `uv run tmux-mcp-report --all` submits every staged file in turn
- [x] `uv run tmux-mcp-report 1.2.3.4.log` submits a single file and moves it to `reported/`
- [x] Non-zero exit code on submission failure (scriptable)
- [x] No env: prints clear error rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)