### PR TITLE
feat(reports): tab-complete tmux-mcp-report and refresh README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,12 +7,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Install deps: `uv sync`
 - Run server: `uv run tmux-mcp`
 - Run enricher: `uv run tmux-mcp-enricher`
-- Submit a staged report: `uv run tmux-mcp-report <filename.log>` (also `--list`, `--all`)
+- Submit a staged report: `uv run tmux-mcp-report <filename.log>` (also `--list`, `--all`). Tab-completion via argcomplete — see below.
 - Lint / format: `uv run ruff check` / `uv run ruff format`
 - Run tests: `uv run pytest`
 - Health check: `curl http://localhost:8747/healthz`
 
 Python 3.13+ is required (see `.python-version`, `pyproject.toml`). Before pushing, every commit should pass `uv run ruff check`, `uv run ruff format --check`, and `uv run pytest` — CI runs the same checks.
+
+### Tab-completion for `tmux-mcp-report`
+
+The CLI uses [`argcomplete`](https://github.com/kislyuk/argcomplete). Register once per shell so that `tmux-mcp-report <TAB>` completes against `logs/staged/*.log`:
+
+```sh
+# bash
+eval "$(register-python-argcomplete tmux-mcp-report)"
+
+# zsh
+autoload -U compinit && compinit
+eval "$(register-python-argcomplete tmux-mcp-report)"
+```
+
+Add the appropriate line to `~/.bashrc` / `~/.zshrc` to make it permanent. The CLI works without registration — completion just won't fire.
 
 ### Pre-commit hooks
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@ on the host machine. Authenticates users via **GitHub OAuth**; the MCP server
 itself is a full OAuth 2.1 authorization server (with Dynamic Client
 Registration), so it works as a remote connector in the Claude mobile app.
 
+## Commands
+
+| Command              | What it does                                                            |
+| -------------------- | ----------------------------------------------------------------------- |
+| `tmux-mcp`           | Run the MCP server (the OAuth + tool host)                              |
+| `tmux-mcp-enricher`  | Watch `logs/pending/`, enrich + move files to `logs/staged/`            |
+| `tmux-mcp-report`    | Submit staged abuse reports from the shell (`--list`, `--all`, or a filename) |
+
+`tmux-mcp-report` supports tab-completion of staged filenames. Enable it once per shell by adding to your `~/.bashrc` or `~/.zshrc`:
+
+```sh
+# bash
+eval "$(register-python-argcomplete tmux-mcp-report)"
+
+# zsh
+autoload -U compinit && compinit
+eval "$(register-python-argcomplete tmux-mcp-report)"
+```
+
 ## Tools
 
 | Tool                  | What it does                                                  |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyjwt[crypto]>=2.8",
     "python-dotenv>=1.0",
     "httpx>=0.27",
+    "argcomplete>=3.6.3",
 ]
 
 [project.scripts]

--- a/src/tmux_mcp/reports.py
+++ b/src/tmux_mcp/reports.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 """Abuse-pipeline reporting — MCP tool implementations and CLI.
 
 Four tools expose the pipeline state and let the agent submit reports:
@@ -30,6 +31,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import argcomplete
 import httpx
 from dotenv import load_dotenv
 
@@ -379,6 +381,23 @@ async def _send_many(log_root: Path, filenames: list[str], api_key: str | None) 
     return 0 if failures == 0 else 1
 
 
+def _staged_completer(prefix: str, **_kwargs) -> list[str]:
+    """argcomplete completer that lists matching staged filenames.
+
+    Reads ``TMUX_MCP_LOG_DIR`` directly (no .env load) so completion stays
+    fast and side-effect-free.
+    """
+    log_root = Path(os.environ.get("TMUX_MCP_LOG_DIR", "./logs")).expanduser()
+    staged = log_root / "staged"
+    if not staged.is_dir():
+        return []
+    return [
+        f.name
+        for f in staged.iterdir()
+        if f.is_file() and f.suffix == ".log" and f.name.startswith(prefix)
+    ]
+
+
 def cli_main() -> int:
     """Console-script entry point for ``tmux-mcp-report``."""
     parser = argparse.ArgumentParser(
@@ -386,11 +405,12 @@ def cli_main() -> int:
         description="Submit staged abuse reports to AbuseIPDB.",
     )
     group = parser.add_mutually_exclusive_group()
-    group.add_argument(
+    filename_arg = group.add_argument(
         "filename",
         nargs="?",
         help="Bare *.log filename in logs/staged/ (e.g. 1.2.3.4.log).",
     )
+    filename_arg.completer = _staged_completer  # type: ignore[attr-defined]
     group.add_argument(
         "--all",
         action="store_true",
@@ -401,6 +421,7 @@ def cli_main() -> int:
         action="store_true",
         help="List staged filenames and exit.",
     )
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     load_dotenv()

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -422,3 +422,37 @@ def test_cli_no_args_errors(log_root, monkeypatch):
     monkeypatch.setattr("sys.argv", ["tmux-mcp-report"])
     with pytest.raises(SystemExit):
         cli_main()
+
+
+def test_staged_completer_matches_prefix(log_root, monkeypatch):
+    from tmux_mcp.reports import _staged_completer
+
+    _write_staged(
+        log_root,
+        "1.2.3.4",
+        {"IP": "1.2.3.4", "AbuseIPDB-Categories": "19"},
+        ["2026-04-23T10:00:00Z GET /.env 429"],
+    )
+    _write_staged(
+        log_root,
+        "1.2.99.99",
+        {"IP": "1.2.99.99", "AbuseIPDB-Categories": "21"},
+        ["2026-04-23T10:00:00Z GET /a 429"],
+    )
+    _write_staged(
+        log_root,
+        "9.9.9.9",
+        {"IP": "9.9.9.9", "AbuseIPDB-Categories": "21"},
+        ["2026-04-23T10:00:00Z GET /b 429"],
+    )
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(log_root))
+    matches = _staged_completer("1.2.")
+    assert sorted(matches) == ["1.2.3.4.log", "1.2.99.99.log"]
+
+
+def test_staged_completer_handles_missing_dir(tmp_path, monkeypatch):
+    from tmux_mcp.reports import _staged_completer
+
+    monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(tmp_path / "nope"))
+    assert _staged_completer("") == []

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -781,6 +790,7 @@ name = "tmux-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "argcomplete" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -798,6 +808,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argcomplete", specifier = ">=3.6.3" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
     { name = "pydantic", specifier = ">=2.7" },


### PR DESCRIPTION
Closes #26

## Summary
- argcomplete wiring: `tmux-mcp-report <TAB>` now lists matching staged filenames. Reads `TMUX_MCP_LOG_DIR` directly so completion stays fast and side-effect-free.
- `CLAUDE.md` gets a "Tab-completion" section with bash + zsh setup.
- `README.md` gains a Commands table listing all three console scripts (`tmux-mcp`, `tmux-mcp-enricher`, `tmux-mcp-report`) plus the completion setup snippet — this is the README update we missed in #24.
- Two new tests cover the completer's prefix matching and the missing-directory case.

## Test plan
- [x] Install: `uv sync` picks up argcomplete
- [x] Register: `eval "$(register-python-argcomplete tmux-mcp-report)"`
- [x] `tmux-mcp-report <TAB>` lists staged *.log filenames
- [x] `tmux-mcp-report 1.<TAB>` filters to matching prefixes
- [x] CLI still works without registration (no completion, no errors)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)