### PR TITLE
feat(reports): add --register flag for shell completion setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,18 +16,18 @@ Python 3.13+ is required (see `.python-version`, `pyproject.toml`). Before pushi
 
 ### Tab-completion for `tmux-mcp-report`
 
-The CLI uses [`argcomplete`](https://github.com/kislyuk/argcomplete). Register once per shell so that `tmux-mcp-report <TAB>` completes against `logs/staged/*.log`:
+The CLI uses [`argcomplete`](https://github.com/kislyuk/argcomplete). Use the built-in helper to print the right snippet for your shell, then append it to your rc file:
 
 ```sh
-# bash
-eval "$(register-python-argcomplete tmux-mcp-report)"
+# auto-detect from $SHELL
+echo "$(uv run tmux-mcp-report --register)" >> ~/.zshrc
 
-# zsh
-autoload -U compinit && compinit
-eval "$(register-python-argcomplete tmux-mcp-report)"
+# explicit
+uv run tmux-mcp-report --register bash >> ~/.bashrc
+uv run tmux-mcp-report --register zsh  >> ~/.zshrc
 ```
 
-Add the appropriate line to `~/.bashrc` / `~/.zshrc` to make it permanent. The CLI works without registration — completion just won't fire.
+Reload the shell (or `source` the rc file) and `tmux-mcp-report <TAB>` completes against `logs/staged/*.log`. The CLI works without registration — completion just won't fire.
 
 ### Pre-commit hooks
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Registration), so it works as a remote connector in the Claude mobile app.
 | `tmux-mcp-enricher`  | Watch `logs/pending/`, enrich + move files to `logs/staged/`            |
 | `tmux-mcp-report`    | Submit staged abuse reports from the shell (`--list`, `--all`, or a filename) |
 
-`tmux-mcp-report` supports tab-completion of staged filenames. Enable it once per shell by adding to your `~/.bashrc` or `~/.zshrc`:
+`tmux-mcp-report` supports tab-completion of staged filenames. The CLI prints the right snippet for your shell — pipe it into your rc file:
 
 ```sh
-# bash
-eval "$(register-python-argcomplete tmux-mcp-report)"
+# auto-detect from $SHELL
+echo "$(tmux-mcp-report --register)" >> ~/.zshrc
 
-# zsh
-autoload -U compinit && compinit
-eval "$(register-python-argcomplete tmux-mcp-report)"
+# or pick the shell explicitly
+tmux-mcp-report --register bash >> ~/.bashrc
+tmux-mcp-report --register zsh  >> ~/.zshrc
 ```
 
 ## Tools

--- a/src/tmux_mcp/reports.py
+++ b/src/tmux_mcp/reports.py
@@ -381,6 +381,31 @@ async def _send_many(log_root: Path, filenames: list[str], api_key: str | None) 
     return 0 if failures == 0 else 1
 
 
+_REGISTER_SHELLS = ("bash", "zsh")
+
+
+def _shell_completion_snippet(shell: str) -> str:
+    """Return the eval-snippet a user pastes into ~/.bashrc or ~/.zshrc."""
+    base = 'eval "$(register-python-argcomplete tmux-mcp-report)"'
+    if shell == "zsh":
+        return (
+            "# Tab-completion for tmux-mcp-report\n"
+            "autoload -U compinit && compinit\n"
+            f"{base}\n"
+        )
+    # bash and unknown shells get the bash form (works in most POSIX shells).
+    return f"# Tab-completion for tmux-mcp-report\n{base}\n"
+
+
+def _detect_shell() -> str:
+    """Detect the user's shell from ``$SHELL``. Default to bash."""
+    shell_env = os.environ.get("SHELL", "")
+    name = Path(shell_env).name if shell_env else ""
+    if name in _REGISTER_SHELLS:
+        return name
+    return "bash"
+
+
 def _staged_completer(prefix: str, **_kwargs) -> list[str]:
     """argcomplete completer that lists matching staged filenames.
 
@@ -421,8 +446,24 @@ def cli_main() -> int:
         action="store_true",
         help="List staged filenames and exit.",
     )
+    group.add_argument(
+        "--register",
+        nargs="?",
+        const="",
+        choices=("", *_REGISTER_SHELLS),
+        metavar="SHELL",
+        help=(
+            "Print shell-completion setup snippet and exit. "
+            "SHELL is bash or zsh (defaults to autodetect from $SHELL)."
+        ),
+    )
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
+
+    if args.register is not None:
+        shell = args.register or _detect_shell()
+        print(_shell_completion_snippet(shell), end="")
+        return 0
 
     load_dotenv()
     log_root = Path(os.environ.get("TMUX_MCP_LOG_DIR", "./logs")).expanduser()

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -456,3 +456,56 @@ def test_staged_completer_handles_missing_dir(tmp_path, monkeypatch):
 
     monkeypatch.setenv("TMUX_MCP_LOG_DIR", str(tmp_path / "nope"))
     assert _staged_completer("") == []
+
+
+def test_cli_register_bash_prints_snippet(monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--register", "bash"])
+    rc = cli_main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert 'eval "$(register-python-argcomplete tmux-mcp-report)"' in out
+    assert "compinit" not in out
+
+
+def test_cli_register_zsh_includes_compinit(monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--register", "zsh"])
+    rc = cli_main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "autoload -U compinit && compinit" in out
+    assert 'eval "$(register-python-argcomplete tmux-mcp-report)"' in out
+
+
+def test_cli_register_autodetect_zsh_from_env(monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--register"])
+    rc = cli_main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "compinit" in out
+
+
+def test_cli_register_autodetect_falls_back_to_bash(monkeypatch, capsys):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.delenv("SHELL", raising=False)
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--register"])
+    rc = cli_main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "compinit" not in out
+    assert 'eval "$(register-python-argcomplete tmux-mcp-report)"' in out
+
+
+def test_cli_register_unknown_shell_rejected(monkeypatch):
+    from tmux_mcp.reports import cli_main
+
+    monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--register", "fish"])
+    with pytest.raises(SystemExit):
+        cli_main()


### PR DESCRIPTION
Closes #28

## Summary
- New `--register [bash|zsh]` flag prints the shell-completion eval snippet to stdout. Auto-detects from `$SHELL` when no arg is given, falls back to bash for unknown shells. zsh snippet includes the `compinit` preamble.
- README + CLAUDE.md updated to use `tmux-mcp-report --register` as the canonical setup path.
- 5 new tests covering both shells, autodetect (zsh + fallback), and rejection of unsupported shells.

## Test plan
- [x] `tmux-mcp-report --register bash` prints just the eval line
- [x] `tmux-mcp-report --register zsh` includes `compinit`
- [x] `tmux-mcp-report --register` with `$SHELL=/usr/bin/zsh` → zsh form
- [x] `tmux-mcp-report --register` with `$SHELL` unset → bash form
- [x] `tmux-mcp-report --register fish` errors out cleanly
- [x] `echo "$(tmux-mcp-report --register)" >> ~/.zshrc` followed by shell reload activates tab completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)