### PR TITLE
fix: import tmux_mcp.reports without OAuth env, find .env from CWD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.scripts]
-tmux-mcp = "tmux_mcp:main"
+tmux-mcp = "tmux_mcp.server:main"
 tmux-mcp-enricher = "tmux_mcp.enricher:main"
 tmux-mcp-report = "tmux_mcp.reports:cli_main"
 

--- a/src/tmux_mcp/__init__.py
+++ b/src/tmux_mcp/__init__.py
@@ -1,3 +1,7 @@
-from tmux_mcp.server import main
+"""tmux-mcp — MCP server bridging Claude Chat ↔ Claude Code via tmux.
 
-__all__ = ["main"]
+Submodules are import-safe: importing ``tmux_mcp.reports`` (or any other
+module) does not pull in the OAuth-server config and therefore does not
+require the server's env vars to be set. The ``tmux-mcp`` console script
+points at ``tmux_mcp.server:main`` directly.
+"""

--- a/src/tmux_mcp/enricher.py
+++ b/src/tmux_mcp/enricher.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 
 logger = logging.getLogger("tmux_mcp.enricher")
@@ -414,7 +414,7 @@ def main() -> None:
     forever. Runs independently of the MCP server — start it alongside via
     systemd, supervisor, tmux, or anything else.
     """
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",

--- a/src/tmux_mcp/reports.py
+++ b/src/tmux_mcp/reports.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 import argcomplete
 import httpx
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from tmux_mcp.enricher import promote_file
 
@@ -465,7 +465,7 @@ def cli_main() -> int:
         print(_shell_completion_snippet(shell), end="")
         return 0
 
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
     log_root = Path(os.environ.get("TMUX_MCP_LOG_DIR", "./logs")).expanduser()
     api_key = os.environ.get("TMUX_MCP_ABUSEIPDB_KEY")
 

--- a/src/tmux_mcp/server.py
+++ b/src/tmux_mcp/server.py
@@ -23,7 +23,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -38,8 +38,10 @@ from tmux_mcp.auth import STATE_DIR, GithubOAuthProvider
 from tmux_mcp.ratelimit import RateLimitMiddleware
 from tmux_mcp import reports as _reports
 
-# Load .env from CWD or project root before any env reads.
-load_dotenv()
+# Load .env by walking up from the user's CWD (not the install location).
+# Without ``usecwd=True`` find_dotenv would walk up from this file, which
+# never reaches the user's repo when tmux-mcp is installed via ``uv tool``.
+load_dotenv(find_dotenv(usecwd=True))
 
 # ── Config ───────────────────────────────────────────────────────────────────
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -509,3 +512,27 @@ def test_cli_register_unknown_shell_rejected(monkeypatch):
     monkeypatch.setattr("sys.argv", ["tmux-mcp-report", "--register", "fish"])
     with pytest.raises(SystemExit):
         cli_main()
+
+
+def test_reports_import_does_not_require_oauth_env(tmp_path):
+    """Regression for #32: importing tmux_mcp.reports in a process with no
+    OAuth env vars must not trigger server.py's validation. Runs in a
+    subprocess so conftest's env doesn't leak in, and CWD is set to a
+    temp dir so find_dotenv has nothing to find on the upward walk.
+    """
+    clean_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(tmp_path),
+        "PYTHONPATH": os.pathsep.join(sys.path),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", "import tmux_mcp.reports"],
+        env=clean_env,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, (
+        f"importing tmux_mcp.reports failed in clean env:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
Closes #32

## Summary
- Drop the `from tmux_mcp.server import main` re-export in `__init__.py`. Submodule imports no longer transitively pull in the OAuth env-var validation, so `tmux-mcp-report` and friends start cleanly without those vars set.
- Repoint the `tmux-mcp` console script to `tmux_mcp.server:main` directly so the change above doesn't break it.
- Replace `load_dotenv()` with `load_dotenv(find_dotenv(usecwd=True))` in `server.py`, `enricher.py`, and `reports.py` — `.env` is now found by walking up from the user's CWD instead of the install location, which fixes globally installed CLIs.
- Subprocess regression test imports `tmux_mcp.reports` in a clean env from a temp CWD and asserts no SystemExit.

## Test plan
- [x] After `uv tool install .`, `tmux-mcp-report --list` runs from any directory without OAuth env vars
- [x] After `uv tool install .`, `tmux-mcp` from the repo root picks up `.env` and starts the server
- [x] `uv run tmux-mcp` and `uv run tmux-mcp-report` still work
- [x] `tmux-mcp` aborts with the same Missing-env-vars error when run from a directory with no `.env` and no env vars set
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)